### PR TITLE
feat: narrow odroe.dev to website-only scope

### DIFF
--- a/sites/odroe.dev/.vitepress/config/en.ts
+++ b/sites/odroe.dev/.vitepress/config/en.ts
@@ -3,33 +3,20 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   lang: "en-US",
   description:
-    "Spry-first Dart infrastructure for file-routed servers, cross-runtime deployment, and practical AI-assisted DX.",
+    "Odroe is now maintained as a website-only public entry. Historical packages and experiments are archived and no longer actively maintained.",
   head: [
     [
       "meta",
       {
         property: "og:title",
         content:
-          "Odroe | Spry-first Dart infrastructure across runtimes.",
+          "Odroe | Website-only public entry",
       },
     ],
   ],
 
   themeConfig: {
-    nav: [{ text: "Packages", link: "/packages/" }],
-    sidebar: [
-      { text: "Dependency Injection", link: "/docs/oinject" },
-      { text: "Memoization", link: "/docs/oncecall" },
-      {
-        text: "Reactive",
-        items: [
-          { text: "Introduction", link: "/docs/oref/introduction" },
-          { text: "Getting Started", link: "/docs/oref/get-started" },
-          { text: "Core", link: "/docs/oref/core" },
-          { text: "Utilities", link: "/docs/oref/utils" },
-          { text: "Advanced", link: "/docs/oref/advanced" },
-        ],
-      },
-    ],
+    nav: [],
+    sidebar: [],
   },
 });

--- a/sites/odroe.dev/.vitepress/config/en.ts
+++ b/sites/odroe.dev/.vitepress/config/en.ts
@@ -3,14 +3,14 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   lang: "en-US",
   description:
-    "For reactive programming and dependency injection in Dart and Flutter applications, as well as various utilities and tools.",
+    "Spry-first Dart infrastructure for file-routed servers, cross-runtime deployment, and practical AI-assisted DX.",
   head: [
     [
       "meta",
       {
         property: "og:title",
         content:
-          "Odroe | For reactive programming and dependency injection in Dart and Flutter applications, as well as various utilities and tools.",
+          "Odroe | Spry-first Dart infrastructure across runtimes.",
       },
     ],
   ],

--- a/sites/odroe.dev/.vitepress/config/index.ts
+++ b/sites/odroe.dev/.vitepress/config/index.ts
@@ -37,7 +37,7 @@ export default defineConfig({
 
     socialLinks: [
       { icon: "github", link: "https://github.com/odroe/odroe" },
-      { icon: "x", link: "https://x.com/shiweidu" },
+      { icon: "x", link: "https://x.com/OdroeDev" },
       { icon: "discord", link: "https://odroe.dev/chat" },
     ],
   },

--- a/sites/odroe.dev/.vitepress/config/zh.ts
+++ b/sites/odroe.dev/.vitepress/config/zh.ts
@@ -3,34 +3,21 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   lang: "zh-Hans",
   description:
-    "以 Spry 为先的 Dart 基础设施，聚焦文件路由服务端、多运行时交付与务实的 AI 辅助开发体验。",
+    "Odroe 现阶段只保留官网入口。历史 packages 与实验项目已转为归档视角，不再作为持续维护对象。",
   head: [
     [
       "meta",
       {
         property: "og:title",
         content:
-          "Odroe | 面向多运行时交付的 Spry 优先 Dart 基础设施。",
+          "Odroe | 仅保留官网入口",
       },
     ],
   ],
 
   themeConfig: {
-    nav: [{ text: "Packages", link: "/zh/packages/" }],
-    sidebar: [
-      { text: "依赖注入", link: "/zh/docs/oinject" },
-      { text: "记忆化", link: "/zh/docs/oncecall" },
-      {
-        text: "响应式",
-        items: [
-          { text: "介绍", link: "/zh/docs/oref/introduction" },
-          { text: "快速开始", link: "/zh/docs/oref/get-started" },
-          { text: "核心", link: "/zh/docs/oref/core" },
-          { text: "工具", link: "/zh/docs/oref/utils" },
-          { text: "进阶", link: "/zh/docs/oref/advanced" },
-        ],
-      },
-    ],
+    nav: [],
+    sidebar: [],
     lastUpdatedText: "更新于",
   },
 });

--- a/sites/odroe.dev/.vitepress/config/zh.ts
+++ b/sites/odroe.dev/.vitepress/config/zh.ts
@@ -3,14 +3,14 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   lang: "zh-Hans",
   description:
-    "为 Dart 和 Flutter 应用程序中的反应式编程和依赖注入以及各种实用程序和工具。",
+    "以 Spry 为先的 Dart 基础设施，聚焦文件路由服务端、多运行时交付与务实的 AI 辅助开发体验。",
   head: [
     [
       "meta",
       {
         property: "og:title",
         content:
-          "Odroe | 为 Dart 和 Flutter 应用程序中的反应式编程和依赖注入以及各种实用程序和工具。",
+          "Odroe | 面向多运行时交付的 Spry 优先 Dart 基础设施。",
       },
     ],
   ],

--- a/sites/odroe.dev/en/index.md
+++ b/sites/odroe.dev/en/index.md
@@ -1,47 +1,47 @@
 ---
-title: Spry-first Dart infrastructure for teams shipping across runtimes.
+title: Odroe is now maintained as a website-only public entry.
 layout: home
 hero:
-  name: Spry-first Dart infrastructure for teams shipping across runtimes.
-  tagline: Odroe builds around Spry, Oref, and practical AI-assisted DX so one Dart codebase can move across Dart VM, Node.js, Bun, Deno, Cloudflare Workers, Vercel, and Netlify.
+  name: Odroe is now maintained as a website-only public entry.
+  tagline: This site remains as the public home for Odroe. Historical Dart and Flutter packages, experiments, and ecosystem claims are archived and no longer part of the active maintenance scope.
   image:
     light: /hero-light.png
     dark: /hero-dark.png
   actions:
     - theme: brand
-      text: Start with Spry →
-      link: https://spry.medz.dev/getting-started
+      text: Visit GitHub
+      link: https://github.com/odroe
     - theme: alt
-      text: Browse Packages
-      link: /packages/
+      text: Follow on X
+      link: https://x.com/OdroeDev
   what-is-new:
-    title: Current focus: file-routed servers, reactive foundations, and inspectable output for AI-assisted workflows.
-    link: https://github.com/medz/spry
+    title: "Scope update: only website assets remain active. Legacy packages and experiments are retained only as historical context."
+    link: https://github.com/odroe
 features:
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
       </svg>
-    title: Spry for file-routed servers
-    details: Define routes from the filesystem, keep deployment targets flexible, and stay close to concrete runtime output instead of hiding behind a giant DSL.
+    title: Website-only scope
+    details: "Odroe now keeps a narrow public surface area: the website, the organization profile, and the minimum assets needed to keep those entry points accurate."
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
       </svg>
-    title: Cross-runtime by design
-    details: Ship the same Dart server project to Dart VM, Node.js, Bun, Deno, Cloudflare Workers, Vercel, and Netlify without rewriting route code for each platform.
+    title: Legacy packages are not active products
+    details: Older package pages, experiments, and monorepo code are no longer promoted as active offerings. They should be treated as archival material unless explicitly revived later.
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3" />
       </svg>
-    title: Oref and pragmatic building blocks
-    details: Layer Oref, Oinject, Oncecall, and companion packages on top when you need low-invasive reactivity, dependency injection, or focused app tooling.
+    title: Lower maintenance surface
+    details: Reducing the public surface keeps CCO work inside a realistic operating boundary and avoids pretending abandoned repositories are still under active care.
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-1.313-4.593a.75.75 0 0 0-1.036-.482l-2.75 1.179 1.353-3.086a.75.75 0 0 0-.104-.777L3 8.25l3.457.103a.75.75 0 0 0 .665-.34L9 5.25l1.878 2.763a.75.75 0 0 0 .665.34L15 8.25l-2.15 2.741a.75.75 0 0 0-.104.777l1.353 3.086-2.75-1.179a.75.75 0 0 0-1.036.482L9.813 15.904ZM18.25 8.25h3.5m-1.75-1.75v3.5m-1.75 8.25h3.5m-1.75-1.75v3.5" />
       </svg>
-    title: AI-assisted DX without black boxes
-    details: Keep generated output inspectable, align OpenAPI with typed clients, and give AI tools artifacts they can reason about instead of opaque framework state.
+    title: Clear public expectation
+    details: "The website should communicate current scope plainly: what remains active, what is only historical, and where not to expect ongoing maintenance."
 ---
 
 <script setup>
@@ -58,10 +58,10 @@ import members from '../.vitepress/data/members';
 
 <VPTeamPageTitle>
   <template #title>
-    Made by the Community
+    Public Entry
   </template>
   <template #lead>
-    Say hello to our outstanding contributors.
+    The website stays online as the minimal front door for the Odroe organization.
   </template>
 </VPTeamPageTitle>
 

--- a/sites/odroe.dev/en/index.md
+++ b/sites/odroe.dev/en/index.md
@@ -1,38 +1,47 @@
 ---
-title: Open-source reactive programming and dependency injection for Dart and Flutter applications, along with various utilities and tools.
+title: Spry-first Dart infrastructure for teams shipping across runtimes.
 layout: home
 hero:
-  name: Unleash Dart's Potential with the Odroe Ecosystem
-  tagline: Dart/Flutter libraries, tools, and utilities designed to enhance your coding journey.
+  name: Spry-first Dart infrastructure for teams shipping across runtimes.
+  tagline: Odroe builds around Spry, Oref, and practical AI-assisted DX so one Dart codebase can move across Dart VM, Node.js, Bun, Deno, Cloudflare Workers, Vercel, and Netlify.
   image:
     light: /hero-light.png
     dark: /hero-dark.png
   actions:
     - theme: brand
-      text: Explore Odroe Ecosystem →
+      text: Start with Spry →
+      link: https://spry.medz.dev/getting-started
+    - theme: alt
+      text: Browse Packages
       link: /packages/
   what-is-new:
-    title: The Odroe ecosystem is under construction, please give us a 🌟 on GitHub
-    link: https://github.com/odroe/odroe
+    title: Current focus: file-routed servers, reactive foundations, and inspectable output for AI-assisted workflows.
+    link: https://github.com/medz/spry
 features:
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
       </svg>
-    title: High-quality & Single-purpose
-    details: Each package is carefully crafted and focused on specific functionality, making it easy to understand and use.
+    title: Spry for file-routed servers
+    details: Define routes from the filesystem, keep deployment targets flexible, and stay close to concrete runtime output instead of hiding behind a giant DSL.
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
       </svg>
-    title: Collaboration and Community
-    details: We welcome new ideas, feedback, and code contributions with open arms, building an innovative and reliable open-source community together.
+    title: Cross-runtime by design
+    details: Ship the same Dart server project to Dart VM, Node.js, Bun, Deno, Cloudflare Workers, Vercel, and Netlify without rewriting route code for each platform.
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3" />
       </svg>
-    title: Consistency
-    details: Each package follows best practices and is tailored into user-friendly APIs and low-level functions, ensuring smooth compatibility when combined.
+    title: Oref and pragmatic building blocks
+    details: Layer Oref, Oinject, Oncecall, and companion packages on top when you need low-invasive reactivity, dependency injection, or focused app tooling.
+  - icon: >-
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-1.313-4.593a.75.75 0 0 0-1.036-.482l-2.75 1.179 1.353-3.086a.75.75 0 0 0-.104-.777L3 8.25l3.457.103a.75.75 0 0 0 .665-.34L9 5.25l1.878 2.763a.75.75 0 0 0 .665.34L15 8.25l-2.15 2.741a.75.75 0 0 0-.104.777l1.353 3.086-2.75-1.179a.75.75 0 0 0-1.036.482L9.813 15.904ZM18.25 8.25h3.5m-1.75-1.75v3.5m-1.75 8.25h3.5m-1.75-1.75v3.5" />
+      </svg>
+    title: AI-assisted DX without black boxes
+    details: Keep generated output inspectable, align OpenAPI with typed clients, and give AI tools artifacts they can reason about instead of opaque framework state.
 ---
 
 <script setup>

--- a/sites/odroe.dev/en/packages/index.md
+++ b/sites/odroe.dev/en/packages/index.md
@@ -1,40 +1,22 @@
 ---
-title: Packages
-description: Prepared for developers, quickly pick your favorite Package.
+title: Archive
+description: Historical package pages are retained only as archival context. They are not actively maintained.
 layout: home
 hero:
-  name: Start with Spry
-  tagline: Build the file-routed server first, then add Oref and supporting packages when you need reactive foundations or focused app tooling.
+  name: Archived package pages
+  tagline: Odroe no longer maintains this package collection as an active product surface. The website remains, but historical packages and experiments are outside the current maintenance scope.
   actions:
     - theme: brand
-      text: Start with Spry
-      link: https://spry.medz.dev/getting-started
+      text: Visit GitHub
+      link: https://github.com/odroe
     - theme: alt
-      text: Explore on pub.dev
-      link: https://pub.dev/publishers/odroe.dev
+      text: Follow on X
+      link: https://x.com/OdroeDev
 features:
-  - title: Spry
-    details: File-routing Dart server framework for teams that want one codebase across Dart VM, Node.js, Bun, Deno, Cloudflare Workers, Vercel, and Netlify.
-    link: https://spry.fun
-    linkText: Visit Spry
-  - title: Oref
-    details: Low-invasive reactivity for Dart and Flutter when you need state, effects, and derived data without a large runtime abstraction layer.
-    link: /packages/oref
-    linkText: Learn more
-  - title: Oinject
-    details: A focused dependency injection package for wiring services and shared state without heavy ceremony.
-    link: /packages/oinject
-    linkText: Learn more
-  - title: Oncecall
-    details: Memoization utilities for Flutter build flows when you need stable initialization around widget context.
-    link: /packages/oncecall
-    linkText: Learn more
-  - title: Oref Flutter
-    details: Flutter bindings for Oref so reactive state can stay close to widgets without replacing your entire app model.
-    link: /docs/oref/get-started
-    linkText: Getting Started
-  - title: Prisma Dart
-    details: Type-safe database tooling for Dart projects that still need an ORM in the broader Odroe package lineup.
-    link: https://prisma.pub
-    linkText: Visit Prisma Dart
+  - title: No active maintenance
+    details: These package pages remain only so older links do not break abruptly. They should not be read as active roadmap, support, or compatibility commitments.
+  - title: Website remains the only active surface
+    details: Current CCO maintenance for Odroe is limited to the website and organization entry assets, not the historical package ecosystem.
+  - title: Legacy material may be removed later
+    details: Outdated package and experiment pages are candidates for deletion or archival once the remaining public entry points are cleaned up.
 ---

--- a/sites/odroe.dev/en/packages/index.md
+++ b/sites/odroe.dev/en/packages/index.md
@@ -3,45 +3,38 @@ title: Packages
 description: Prepared for developers, quickly pick your favorite Package.
 layout: home
 hero:
-  name: Packages
-  tagline: Carefully crafted, each package makes you enjoy coding ❤️
+  name: Start with Spry
+  tagline: Build the file-routed server first, then add Oref and supporting packages when you need reactive foundations or focused app tooling.
   actions:
     - theme: brand
-      text: ♥ Support @medz
-      link: https://github.com/sponsors/medz
+      text: Start with Spry
+      link: https://spry.medz.dev/getting-started
     - theme: alt
       text: Explore on pub.dev
       link: https://pub.dev/publishers/odroe.dev
 features:
-  - title: Prisma Dart
-    details: The next generation ORM for Dart/Flutter, automatically generates type-safe database clients for you.
-    link: https://prisma.pub
-    linkText: Visit Prisma Dart's website
   - title: Spry
-    details: A lightweight composable Web framework.
+    details: File-routing Dart server framework for teams that want one codebase across Dart VM, Node.js, Bun, Deno, Cloudflare Workers, Vercel, and Netlify.
     link: https://spry.fun
-    linkText: Visit Spry's official website
+    linkText: Visit Spry
+  - title: Oref
+    details: Low-invasive reactivity for Dart and Flutter when you need state, effects, and derived data without a large runtime abstraction layer.
+    link: /packages/oref
+    linkText: Learn more
   - title: Oinject
-    details: A simple yet powerful dependency injection package. Transparent data, simple state management, smooth replacement for Provider and InheritedWidget.
+    details: A focused dependency injection package for wiring services and shared state without heavy ceremony.
     link: /packages/oinject
     linkText: Learn more
   - title: Oncecall
-    details: A memoization tool for Flutter Widget.build method.
+    details: Memoization utilities for Flutter build flows when you need stable initialization around widget context.
     link: /packages/oncecall
     linkText: Learn more
-  - title: >-
-      <div class="flex flex-row items-center justify-between">
-        <span>Oref</span>
-        <span class="text-xs text-green-500">
-          <span class="text-red-400">♥</span>
-          Vue.js
-        </span>
-      </div>
-    details: A lightweight, high-performance reactive state and programming library that provides a concise and powerful method to manage application state and side effects.
-    link: /packages/oref
-    linkText: Learn more
   - title: Oref Flutter
-    details: A bridge to use Oref with Flutter, enjoy reactive state in Flutter.
+    details: Flutter bindings for Oref so reactive state can stay close to widgets without replacing your entire app model.
     link: /docs/oref/get-started
     linkText: Getting Started
+  - title: Prisma Dart
+    details: Type-safe database tooling for Dart projects that still need an ORM in the broader Odroe package lineup.
+    link: https://prisma.pub
+    linkText: Visit Prisma Dart
 ---

--- a/sites/odroe.dev/zh/index.md
+++ b/sites/odroe.dev/zh/index.md
@@ -1,38 +1,47 @@
 ---
-title: 开源的 Dart 和 Flutter 应用程序中的反应式编程和依赖注入以及各种实用程序和工具。
+title: 面向多运行时交付团队的 Spry 优先 Dart 基础设施。
 layout: home
 hero:
-  name: 利用 Odroe 生态系统释放 Dart/Flutter 的潜力
-  tagline: Dart/Flutter 库、工具和实用程序，旨在提升您的编码之旅。
+  name: 面向多运行时交付团队的 Spry 优先 Dart 基础设施。
+  tagline: Odroe 围绕 Spry、Oref 与务实的 AI 辅助开发体验构建，让同一套 Dart 代码库可以运行在 Dart VM、Node.js、Bun、Deno、Cloudflare Workers、Vercel 与 Netlify。
   image:
     light: /hero-light.png
     dark: /hero-dark.png
   actions:
     - theme: brand
-      text: 探索 Odroe 生态 →
+      text: 从 Spry 开始 →
+      link: https://spry.medz.dev/getting-started
+    - theme: alt
+      text: 浏览 Packages
       link: /zh/packages/
   what-is-new:
-    title: Odroe 生态正在建设中，请在 GitHub 给我们一个 🌟
-    link: https://github.com/odroe/odroe
+    title: 当前重点：文件路由服务端、响应式基础能力，以及便于 AI 协作的可检查产物。
+    link: https://github.com/medz/spry
 features:
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
       </svg>
-    title: 高品质、单一用途
-    details: 每个包都经过精心制作并专注于特定功能，使其易于理解与实用。
+    title: 用 Spry 构建文件路由服务端
+    details: 直接用文件系统定义路由，保持部署目标灵活，让运行时代码保持可见，而不是被巨大的 DSL 隐藏起来。
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
       </svg>
-    title: 协作与社区
-    details: 张开双臂欢迎新想法、反馈和代码贡献，一起组建具有创新和可靠的开源社区。
+    title: 天生面向多运行时
+    details: 同一个 Dart 服务端项目可以交付到 Dart VM、Node.js、Bun、Deno、Cloudflare Workers、Vercel 与 Netlify，而不需要为每个平台重写路由代码。
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3" />
       </svg>
-    title: 一致性
-    details: 每个包都遵循最佳实践并切割为易用的 API 和低级函数，确保顺利组合的兼容性。
+    title: Oref 与务实基础能力
+    details: 当你需要低侵入响应式、依赖注入或聚焦型应用工具时，再按需叠加 Oref、Oinject、Oncecall 与配套包。
+  - icon: >-
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-1.313-4.593a.75.75 0 0 0-1.036-.482l-2.75 1.179 1.353-3.086a.75.75 0 0 0-.104-.777L3 8.25l3.457.103a.75.75 0 0 0 .665-.34L9 5.25l1.878 2.763a.75.75 0 0 0 .665.34L15 8.25l-2.15 2.741a.75.75 0 0 0-.104.777l1.353 3.086-2.75-1.179a.75.75 0 0 0-1.036.482L9.813 15.904ZM18.25 8.25h3.5m-1.75-1.75v3.5m-1.75 8.25h3.5m-1.75-1.75v3.5" />
+      </svg>
+    title: 不靠黑盒的 AI 辅助开发体验
+    details: 保持生成产物可检查，让 OpenAPI 与类型化客户端对齐，并为 AI 工具提供可推理的真实工件，而不是不透明的框架状态。
 ---
 
 <script setup>

--- a/sites/odroe.dev/zh/index.md
+++ b/sites/odroe.dev/zh/index.md
@@ -1,47 +1,47 @@
 ---
-title: 面向多运行时交付团队的 Spry 优先 Dart 基础设施。
+title: Odroe 现阶段仅保留官网入口。
 layout: home
 hero:
-  name: 面向多运行时交付团队的 Spry 优先 Dart 基础设施。
-  tagline: Odroe 围绕 Spry、Oref 与务实的 AI 辅助开发体验构建，让同一套 Dart 代码库可以运行在 Dart VM、Node.js、Bun、Deno、Cloudflare Workers、Vercel 与 Netlify。
+  name: Odroe 现阶段仅保留官网入口。
+  tagline: 这个站点继续作为 Odroe 的公开入口保留。历史上的 Dart / Flutter packages、实验项目与生态叙事已转为归档视角，不再属于活跃维护范围。
   image:
     light: /hero-light.png
     dark: /hero-dark.png
   actions:
     - theme: brand
-      text: 从 Spry 开始 →
-      link: https://spry.medz.dev/getting-started
+      text: 访问 GitHub
+      link: https://github.com/odroe
     - theme: alt
-      text: 浏览 Packages
-      link: /zh/packages/
+      text: 关注 X
+      link: https://x.com/OdroeDev
   what-is-new:
-    title: 当前重点：文件路由服务端、响应式基础能力，以及便于 AI 协作的可检查产物。
-    link: https://github.com/medz/spry
+    title: 范围更新：只有官网资产仍然活跃维护；历史 packages 与实验仓库仅保留为背景信息。
+    link: https://github.com/odroe
 features:
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
       </svg>
-    title: 用 Spry 构建文件路由服务端
-    details: 直接用文件系统定义路由，保持部署目标灵活，让运行时代码保持可见，而不是被巨大的 DSL 隐藏起来。
+    title: 仅保留官网范围
+    details: Odroe 现在只保留官网、组织资料与维持这些公开入口准确所必需的最小资产。
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
       </svg>
-    title: 天生面向多运行时
-    details: 同一个 Dart 服务端项目可以交付到 Dart VM、Node.js、Bun、Deno、Cloudflare Workers、Vercel 与 Netlify，而不需要为每个平台重写路由代码。
+    title: 历史 packages 不再作为活跃产品
+    details: 旧的 packages 页面、实验项目与 monorepo 代码不再对外宣传为活跃产品；除非未来明确重启，否则一律按归档材料看待。
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3" />
       </svg>
-    title: Oref 与务实基础能力
-    details: 当你需要低侵入响应式、依赖注入或聚焦型应用工具时，再按需叠加 Oref、Oinject、Oncecall 与配套包。
+    title: 降低维护面
+    details: 缩小公开维护面，才能让 CCO 的长期动作停留在真实可维护边界内，而不是继续为已经废弃的仓库背书。
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-1.313-4.593a.75.75 0 0 0-1.036-.482l-2.75 1.179 1.353-3.086a.75.75 0 0 0-.104-.777L3 8.25l3.457.103a.75.75 0 0 0 .665-.34L9 5.25l1.878 2.763a.75.75 0 0 0 .665.34L15 8.25l-2.15 2.741a.75.75 0 0 0-.104.777l1.353 3.086-2.75-1.179a.75.75 0 0 0-1.036.482L9.813 15.904ZM18.25 8.25h3.5m-1.75-1.75v3.5m-1.75 8.25h3.5m-1.75-1.75v3.5" />
       </svg>
-    title: 不靠黑盒的 AI 辅助开发体验
-    details: 保持生成产物可检查，让 OpenAPI 与类型化客户端对齐，并为 AI 工具提供可推理的真实工件，而不是不透明的框架状态。
+    title: 对外预期更清晰
+    details: 官网应该直接说明什么仍在维护、什么只是历史遗留，避免让外部继续把废弃项目理解成当前承诺。
 ---
 
 <script setup>
@@ -58,10 +58,10 @@ import members from '../.vitepress/data/members';
 
 <VPTeamPageTitle>
   <template #title>
-    由社区制作
+    公开入口
   </template>
   <template #lead>
-    向我们出色的贡献者问好。
+    官网继续保留，作为 Odroe 组织最小但准确的公开入口。
   </template>
 </VPTeamPageTitle>
 

--- a/sites/odroe.dev/zh/packages/index.md
+++ b/sites/odroe.dev/zh/packages/index.md
@@ -1,40 +1,22 @@
 ---
-title: Packages
-description: 专为开发人员准备、快速挑选你心仪的 Package。
+title: Archive
+description: 历史 package 页面仅作为归档信息保留，不再视为活跃维护内容。
 layout: home
 hero:
-  name: 先从 Spry 开始
-  tagline: 先搭建文件路由服务端，再在需要响应式基础能力或聚焦型应用工具时叠加 Oref 与配套包。
+  name: 历史 package 页面
+  tagline: Odroe 不再把这组 packages 作为活跃产品面维护。官网仍然保留，但历史 packages 与实验项目不在当前维护范围内。
   actions:
     - theme: brand
-      text: 从 Spry 开始
-      link: https://spry.medz.dev/getting-started
+      text: 访问 GitHub
+      link: https://github.com/odroe
     - theme: alt
-      text: 在 pub.dev 上探索
-      link: https://pub.dev/publishers/odroe.dev
+      text: 关注 X
+      link: https://x.com/OdroeDev
 features:
-  - title: Spry
-    details: 面向希望用同一套代码库交付到 Dart VM、Node.js、Bun、Deno、Cloudflare Workers、Vercel 与 Netlify 团队的文件路由 Dart 服务端框架。
-    link: https://spry.fun
-    linkText: 访问 Spry 官网
-  - title: Oref
-    details: 面向 Dart 与 Flutter 的低侵入响应式基础能力，用更小的抽象层处理状态、副作用与派生数据。
-    link: /zh/packages/oref
-    linkText: 了解更多
-  - title: Oinject
-    details: 一个聚焦型依赖注入包，用更少样板代码组织服务与共享状态。
-    link: /zh/packages/oinject
-    linkText: 了解更多
-  - title: Oncecall
-    details: 面向 Flutter build 流程的记忆化工具，适合围绕 Widget 上下文做稳定初始化。
-    link: /zh/packages/oncecall
-    linkText: 了解更多
-  - title: Oref Flutter
-    details: Oref 的 Flutter 绑定，让响应式状态可以贴近 Widget 使用，而不必重写整套应用模型。
-    link: /zh/docs/oref/get-started
-    linkText: 快速开始
-  - title: Prisma Dart
-    details: 仍属于 Odroe 包矩阵中的类型安全数据库工具，适合需要 ORM 的 Dart 项目。
-    link: https://prisma.pub
-    linkText: 查看 Prisma Dart 网站
+  - title: 不再活跃维护
+    details: 这些 package 页面只是在短期内避免旧链接立即失效，不应再被理解为路线图、支持承诺或兼容性承诺。
+  - title: 官网是唯一活跃维护面
+    details: 当前 Odroe 的 CCO 维护范围被限制在官网与组织入口资产，不再覆盖历史 package 生态。
+  - title: 历史材料后续可能继续删除
+    details: 当剩余公开入口完成清理后，过时的 package 与实验页面仍然可以继续归档或直接删除。
 ---

--- a/sites/odroe.dev/zh/packages/index.md
+++ b/sites/odroe.dev/zh/packages/index.md
@@ -3,45 +3,38 @@ title: Packages
 description: 专为开发人员准备、快速挑选你心仪的 Package。
 layout: home
 hero:
-  name: Packages
-  tagline: 精心制作、每一个包都让你享受编码的乐趣❤️
+  name: 先从 Spry 开始
+  tagline: 先搭建文件路由服务端，再在需要响应式基础能力或聚焦型应用工具时叠加 Oref 与配套包。
   actions:
     - theme: brand
-      text: ♥ 支持 @medz 的努力
-      link: https://github.com/sponsors/medz
+      text: 从 Spry 开始
+      link: https://spry.medz.dev/getting-started
     - theme: alt
       text: 在 pub.dev 上探索
       link: https://pub.dev/publishers/odroe.dev
 features:
-  - title: Prisma Dart
-    details: Dart/Flutter 的下一代 ORM，自动为您生成类型安全的数据库客户端。
-    link: https://prisma.pub
-    linkText: 查看 Prisma Dart 的网站
   - title: Spry
-    details: 轻量级的组合式 Web 框架。
+    details: 面向希望用同一套代码库交付到 Dart VM、Node.js、Bun、Deno、Cloudflare Workers、Vercel 与 Netlify 团队的文件路由 Dart 服务端框架。
     link: https://spry.fun
     linkText: 访问 Spry 官网
+  - title: Oref
+    details: 面向 Dart 与 Flutter 的低侵入响应式基础能力，用更小的抽象层处理状态、副作用与派生数据。
+    link: /zh/packages/oref
+    linkText: 了解更多
   - title: Oinject
-    details: 一个简单而强大的依赖注入包。透穿数据、简易状态管理、平滑替代 Provider 和 InheritedWidget。
+    details: 一个聚焦型依赖注入包，用更少样板代码组织服务与共享状态。
     link: /zh/packages/oinject
     linkText: 了解更多
   - title: Oncecall
-    details: 适用于 Flutter Widget.build 方法的记忆化工具。
+    details: 面向 Flutter build 流程的记忆化工具，适合围绕 Widget 上下文做稳定初始化。
     link: /zh/packages/oncecall
     linkText: 了解更多
-  - title: >-
-      <div class="flex flex-row items-center justify-between">
-        <span>Oref</span>
-        <span class="text-xs text-green-500">
-          <span class="text-red-400">♥</span>
-          Vue.js
-        </span>
-      </div>
-    details: 一个轻量级、高性能的响应式状态、编程库，它提供了一种简洁而强大的方法来管理应用程序状态和副作用。
-    link: /zh/packages/oref.md
-    linkText: 了解更多
   - title: Oref Flutter
-    details: 将 Oref 与 Flutter 一起使用的桥，在 Flutter 中享受反应式状态的快乐。
-    link: /zh/docs/oref/get-started.md
+    details: Oref 的 Flutter 绑定，让响应式状态可以贴近 Widget 使用，而不必重写整套应用模型。
+    link: /zh/docs/oref/get-started
     linkText: 快速开始
+  - title: Prisma Dart
+    details: 仍属于 Odroe 包矩阵中的类型安全数据库工具，适合需要 ORM 的 Dart 项目。
+    link: https://prisma.pub
+    linkText: 查看 Prisma Dart 网站
 ---


### PR DESCRIPTION
## Summary
- narrow the English and Chinese site entry points to a website-only public scope
- remove package ecosystem navigation and rewrite the packages landing pages as archival notices
- keep the global X link on @OdroeDev while clarifying that historical packages and experiments are no longer actively maintained

## Testing
- bun install
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Repositioned Odroe as a website-only public entry with archived historical packages no longer actively maintained.
  * Simplified site navigation by removing package menu items.
  * Updated packages section to display archive notice instead of active package listings.
  * Updated social media links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->