### PR TITLE
fix: make odroe.dev copy user-facing

### DIFF
--- a/sites/odroe.dev/.vitepress/config/en.ts
+++ b/sites/odroe.dev/.vitepress/config/en.ts
@@ -3,14 +3,14 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   lang: "en-US",
   description:
-    "Odroe is now maintained as a website-only public entry. Historical packages and experiments are archived and no longer actively maintained.",
+    "Odroe is the public brand and project entry behind practical open source tools, experiments, and developer-facing work from Seven Du.",
   head: [
     [
       "meta",
       {
         property: "og:title",
         content:
-          "Odroe | Website-only public entry",
+          "Odroe | Open source brand and project entry",
       },
     ],
   ],

--- a/sites/odroe.dev/.vitepress/config/zh.ts
+++ b/sites/odroe.dev/.vitepress/config/zh.ts
@@ -3,14 +3,14 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   lang: "zh-Hans",
   description:
-    "Odroe 现阶段只保留官网入口。历史 packages 与实验项目已转为归档视角，不再作为持续维护对象。",
+    "Odroe 是 Seven Du 面向外部的品牌与项目入口，用来承接开源工具、实验项目和开发者产品方向。",
   head: [
     [
       "meta",
       {
         property: "og:title",
         content:
-          "Odroe | 仅保留官网入口",
+          "Odroe | 开源品牌与项目入口",
       },
     ],
   ],

--- a/sites/odroe.dev/en/index.md
+++ b/sites/odroe.dev/en/index.md
@@ -1,70 +1,51 @@
 ---
-title: Odroe is now maintained as a website-only public entry.
+title: Build practical open source tools with Odroe.
 layout: home
 hero:
-  name: Odroe is now maintained as a website-only public entry.
-  tagline: This site remains as the public home for Odroe. Historical Dart and Flutter packages, experiments, and ecosystem claims are archived and no longer part of the active maintenance scope.
+  name: Build practical open source tools with Odroe.
+  tagline: Odroe is the public brand and entry point behind Seven Du's developer-facing open source work, from application foundations to experiments that ship across runtimes.
   image:
     light: /hero-light.png
     dark: /hero-dark.png
   actions:
     - theme: brand
-      text: Visit GitHub
-      link: https://github.com/odroe
+      text: Explore projects
+      link: /packages/
     - theme: alt
       text: Follow on X
       link: https://x.com/OdroeDev
   what-is-new:
-    title: "Scope update: only website assets remain active. Legacy packages and experiments are retained only as historical context."
-    link: https://github.com/odroe
+    title: "Current focus: clear project entry, practical tooling, and public-facing open source updates."
+    link: https://github.com/medz/spry
 features:
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
       </svg>
-    title: Website-only scope
-    details: "Odroe now keeps a narrow public surface area: the website, the organization profile, and the minimum assets needed to keep those entry points accurate."
+    title: Start from real projects
+    details: "Use this site to discover the projects, packages, and public links that matter now instead of digging through scattered repositories first."
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
       </svg>
-    title: Legacy packages are not active products
-    details: Older package pages, experiments, and monorepo code are no longer promoted as active offerings. They should be treated as archival material unless explicitly revived later.
+    title: Practical tooling, not vague ecosystem claims
+    details: Odroe should communicate what people can actually try, adopt, follow, or learn from today instead of hiding behind internal maintenance language.
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3" />
       </svg>
-    title: Lower maintenance surface
-    details: Reducing the public surface keeps CCO work inside a realistic operating boundary and avoids pretending abandoned repositories are still under active care.
+    title: Projects with public context
+    details: The brand site should point people toward repositories, documentation, and active channels so they can understand what Odroe is building now.
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-1.313-4.593a.75.75 0 0 0-1.036-.482l-2.75 1.179 1.353-3.086a.75.75 0 0 0-.104-.777L3 8.25l3.457.103a.75.75 0 0 0 .665-.34L9 5.25l1.878 2.763a.75.75 0 0 0 .665.34L15 8.25l-2.15 2.741a.75.75 0 0 0-.104.777l1.353 3.086-2.75-1.179a.75.75 0 0 0-1.036.482L9.813 15.904ZM18.25 8.25h3.5m-1.75-1.75v3.5m-1.75 8.25h3.5m-1.75-1.75v3.5" />
       </svg>
-    title: Clear public expectation
-    details: "The website should communicate current scope plainly: what remains active, what is only historical, and where not to expect ongoing maintenance."
+    title: User-facing by default
+    details: "Homepage copy should help users, adopters, and contributors understand where to start, what to follow, and why the work matters."
 ---
 
-<script setup>
-import { VPTeamPageTitle, VPTeamMembers } from 'vitepress/theme';
-import members from '../.vitepress/data/members';
-</script>
+## Start Here
 
-<VPTeamPageTitle>
-  <template #title>
-    Our Team
-  </template>
-</VPTeamPageTitle>
-<VPTeamMembers size="small" :members="members" />
-
-<VPTeamPageTitle>
-  <template #title>
-    Public Entry
-  </template>
-  <template #lead>
-    The website stays online as the minimal front door for the Odroe organization.
-  </template>
-</VPTeamPageTitle>
-
-<a href="https://github.com/odroe/odroe/graphs/contributors" >
-  <img src="https://contrib.rocks/image?repo=odroe/odroe" class="mx-auto" />
-</a>
+- Visit [/packages](/packages/) to see the projects and libraries currently worth attention.
+- Follow [@OdroeDev](https://x.com/OdroeDev) for short updates and public progress.
+- Browse [GitHub](https://github.com/odroe) for organization assets and [medz/spry](https://github.com/medz/spry) for the flagship framework direction.

--- a/sites/odroe.dev/en/packages/index.md
+++ b/sites/odroe.dev/en/packages/index.md
@@ -1,22 +1,22 @@
 ---
-title: Archive
-description: Historical package pages are retained only as archival context. They are not actively maintained.
+title: Projects
+description: Explore Odroe projects, libraries, and public entry points that help you understand what to try and follow next.
 layout: home
 hero:
-  name: Archived package pages
-  tagline: Odroe no longer maintains this package collection as an active product surface. The website remains, but historical packages and experiments are outside the current maintenance scope.
+  name: Projects and libraries
+  tagline: Start from the projects and packages that best explain what Odroe is building, experimenting with, and sharing in public.
   actions:
     - theme: brand
-      text: Visit GitHub
-      link: https://github.com/odroe
+      text: View Spry
+      link: https://github.com/medz/spry
     - theme: alt
-      text: Follow on X
-      link: https://x.com/OdroeDev
+      text: View Oref
+      link: https://github.com/medz/oref
 features:
-  - title: No active maintenance
-    details: These package pages remain only so older links do not break abruptly. They should not be read as active roadmap, support, or compatibility commitments.
-  - title: Website remains the only active surface
-    details: Current CCO maintenance for Odroe is limited to the website and organization entry assets, not the historical package ecosystem.
-  - title: Legacy material may be removed later
-    details: Outdated package and experiment pages are candidates for deletion or archival once the remaining public entry points are cleaned up.
+  - title: Spry
+    details: File-routed Dart server tooling and framework work that currently gives Odroe the clearest flagship project story.
+  - title: Oref
+    details: Reactive foundations and supporting building blocks that connect to the broader developer tooling direction.
+  - title: Brand and public entry
+    details: This page should help visitors understand where the main repositories live, what is worth following, and how projects relate to the Odroe brand.
 ---

--- a/sites/odroe.dev/zh/index.md
+++ b/sites/odroe.dev/zh/index.md
@@ -1,70 +1,51 @@
 ---
-title: Odroe 现阶段仅保留官网入口。
+title: 通过 Odroe 构建实用的开源工具。
 layout: home
 hero:
-  name: Odroe 现阶段仅保留官网入口。
-  tagline: 这个站点继续作为 Odroe 的公开入口保留。历史上的 Dart / Flutter packages、实验项目与生态叙事已转为归档视角，不再属于活跃维护范围。
+  name: 通过 Odroe 构建实用的开源工具。
+  tagline: Odroe 是 Seven Du 面向外部的品牌与项目入口，用来展示正在推进的开发者工具、开源项目和公开更新。
   image:
     light: /hero-light.png
     dark: /hero-dark.png
   actions:
     - theme: brand
-      text: 访问 GitHub
-      link: https://github.com/odroe
+      text: 浏览项目
+      link: /zh/packages/
     - theme: alt
       text: 关注 X
       link: https://x.com/OdroeDev
   what-is-new:
-    title: 范围更新：只有官网资产仍然活跃维护；历史 packages 与实验仓库仅保留为背景信息。
-    link: https://github.com/odroe
+    title: 当前重点：让公开入口、项目线索与对外更新重新变得清晰。
+    link: https://github.com/medz/spry
 features:
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
       </svg>
-    title: 仅保留官网范围
-    details: Odroe 现在只保留官网、组织资料与维持这些公开入口准确所必需的最小资产。
+    title: 从真实项目开始
+    details: 这个站点应该帮助用户快速找到现在值得关注的项目、仓库和公开链接，而不是让人先掉进一堆历史资产里。
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
       </svg>
-    title: 历史 packages 不再作为活跃产品
-    details: 旧的 packages 页面、实验项目与 monorepo 代码不再对外宣传为活跃产品；除非未来明确重启，否则一律按归档材料看待。
+    title: 少讲内部边界，多讲公开价值
+    details: Odroe 的对外文案应该解释别人现在能用什么、关注什么、从哪里开始，而不是强调内部维护范围。
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3" />
       </svg>
-    title: 降低维护面
-    details: 缩小公开维护面，才能让 CCO 的长期动作停留在真实可维护边界内，而不是继续为已经废弃的仓库背书。
+    title: 面向采纳与理解
+    details: 官网应该帮助潜在用户、采纳者和贡献者理解这些项目解决什么问题，以及为什么值得继续关注。
   - icon: >-
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-1.313-4.593a.75.75 0 0 0-1.036-.482l-2.75 1.179 1.353-3.086a.75.75 0 0 0-.104-.777L3 8.25l3.457.103a.75.75 0 0 0 .665-.34L9 5.25l1.878 2.763a.75.75 0 0 0 .665.34L15 8.25l-2.15 2.741a.75.75 0 0 0-.104.777l1.353 3.086-2.75-1.179a.75.75 0 0 0-1.036.482L9.813 15.904ZM18.25 8.25h3.5m-1.75-1.75v3.5m-1.75 8.25h3.5m-1.75-1.75v3.5" />
       </svg>
-    title: 对外预期更清晰
-    details: 官网应该直接说明什么仍在维护、什么只是历史遗留，避免让外部继续把废弃项目理解成当前承诺。
+    title: 品牌与项目入口
+    details: Odroe 不是内部说明页，而应该是品牌入口、项目入口和公开更新入口。
 ---
 
-<script setup>
-import { VPTeamPageTitle, VPTeamMembers } from 'vitepress/theme';
-import members from '../.vitepress/data/members';
-</script>
+## 从这里开始
 
-<VPTeamPageTitle>
-  <template #title>
-    认识一下团队成员
-  </template>
-</VPTeamPageTitle>
-<VPTeamMembers size="small" :members="members" />
-
-<VPTeamPageTitle>
-  <template #title>
-    公开入口
-  </template>
-  <template #lead>
-    官网继续保留，作为 Odroe 组织最小但准确的公开入口。
-  </template>
-</VPTeamPageTitle>
-
-<a href="https://github.com/odroe/odroe/graphs/contributors" >
-  <img src="https://contrib.rocks/image?repo=odroe/odroe" class="mx-auto" />
-</a>
+- 访问 [/zh/packages](/zh/packages/) 查看当前最值得关注的项目与库。
+- 关注 [@OdroeDev](https://x.com/OdroeDev) 获取公开更新和项目动态。
+- 查看 [odroe GitHub](https://github.com/odroe) 了解品牌资产，并从 [medz/spry](https://github.com/medz/spry) 理解当前最清晰的项目方向。

--- a/sites/odroe.dev/zh/packages/index.md
+++ b/sites/odroe.dev/zh/packages/index.md
@@ -1,22 +1,22 @@
 ---
-title: Archive
-description: 历史 package 页面仅作为归档信息保留，不再视为活跃维护内容。
+title: 项目
+description: 查看 Odroe 当前最值得关注的项目、库与公开入口，快速理解接下来该看什么、试什么。
 layout: home
 hero:
-  name: 历史 package 页面
-  tagline: Odroe 不再把这组 packages 作为活跃产品面维护。官网仍然保留，但历史 packages 与实验项目不在当前维护范围内。
+  name: 项目与库
+  tagline: 从最能代表 Odroe 当前方向的项目和库开始，理解现在正在构建什么、公开分享什么，以及接下来该关注什么。
   actions:
     - theme: brand
-      text: 访问 GitHub
-      link: https://github.com/odroe
+      text: 查看 Spry
+      link: https://github.com/medz/spry
     - theme: alt
-      text: 关注 X
-      link: https://x.com/OdroeDev
+      text: 查看 Oref
+      link: https://github.com/medz/oref
 features:
-  - title: 不再活跃维护
-    details: 这些 package 页面只是在短期内避免旧链接立即失效，不应再被理解为路线图、支持承诺或兼容性承诺。
-  - title: 官网是唯一活跃维护面
-    details: 当前 Odroe 的 CCO 维护范围被限制在官网与组织入口资产，不再覆盖历史 package 生态。
-  - title: 历史材料后续可能继续删除
-    details: 当剩余公开入口完成清理后，过时的 package 与实验页面仍然可以继续归档或直接删除。
+  - title: Spry
+    details: 面向 Dart 服务端和多运行时场景的框架与工具方向，也是目前最清晰的旗舰项目线索。
+  - title: Oref
+    details: 反应式基础能力与相关构建模块，是当前工具链方向的重要组成部分。
+  - title: 品牌与项目入口
+    details: 这个页面应该帮助访问者理解主要仓库在哪里、当前值得关注什么，以及这些项目和 Odroe 品牌之间的关系。
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Repositioned Odroe from archived website entry to active open source brand and project hub
  * Updated site metadata and homepage messaging across English and Chinese versions
  * Enhanced packages page with direct links to key projects (Spry and Oref)
  * Improved navigation with clearer project discovery pathways

<!-- end of auto-generated comment: release notes by coderabbit.ai -->