### PR TITLE
feat: add style identifier diagnostics

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,36 @@
+name: Dart
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Analyze and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze
+        run: dart analyze .
+
+      - name: Test
+        run: dart test
+
+      - name: Check docs
+        run: dart doc --dry-run .

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    public_member_api_docs: true
+    slash_for_doc_comments: true

--- a/lib/src/style/core.dart
+++ b/lib/src/style/core.dart
@@ -1,5 +1,0 @@
-/// Shared exports for Odroe's platform-neutral style core.
-///
-/// Keep this library limited to declarations that are safe to expose through
-/// `package:odroe/style.dart`.
-library;

--- a/lib/src/style/diagnostic.dart
+++ b/lib/src/style/diagnostic.dart
@@ -1,18 +1,73 @@
-/// Severity for a style-core diagnostic.
-enum DiagnosticSeverity { info, warning, error }
+/// The default importance of a [Diagnostic].
+///
+/// Severity is presentation and policy guidance, not control flow. Validators
+/// still return every diagnostic they find, and callers decide whether a
+/// warning blocks their workflow.
+enum DiagnosticSeverity {
+  /// Context that does not indicate invalid style data.
+  info,
 
-/// Stable diagnostic code constants used by Odroe's style core.
+  /// A problem that should be reviewed by the author.
+  warning,
+
+  /// A problem that normally prevents the style data from being used.
+  error,
+}
+
+/// Machine-readable identifiers for style diagnostics.
+///
+/// Code strings are part of the public contract for validation output. They are
+/// stable handles for tests, editors, and build tooling. Messages can be
+/// rewritten for clarity without changing the corresponding code.
+///
+/// Codes are namespaced by the model area that reports them, such as
+/// `identifier`, and use lower snake case after the dot.
 abstract final class DiagnosticCodes {
+  /// An empty [Identifier.value].
   static const identifierEmpty = 'identifier.empty';
+
+  /// An [Identifier] containing an empty segment.
+  ///
+  /// For example, `color..action` contains an empty segment between the two
+  /// dots.
   static const identifierEmptySegment = 'identifier.empty_segment';
+
+  /// An [Identifier] segment that is not a Dart-friendly path segment.
   static const identifierInvalidSegment = 'identifier.invalid_segment';
+
+  /// An identifier value repeated in one owner scope.
+  ///
+  /// This code is for validators that compare multiple declarations, such as a
+  /// future design manifest or binding validator. [Identifier.validate] does
+  /// not report this code because it only sees one identifier.
   static const identifierDuplicate = 'identifier.duplicate';
+
+  /// Identifier values that differ only by letter case in one owner scope.
+  ///
+  /// This code is reserved for validators that compare declarations in a shared
+  /// namespace. It is not a lexical error for a single [Identifier].
   static const identifierDuplicateIgnoringCase =
       'identifier.duplicate_ignoring_case';
 }
 
-/// A structured diagnostic produced by validation or policy code.
+/// A non-throwing validation result for style-core data.
+///
+/// Style validation reports diagnostics instead of throwing so authoring tools
+/// can show every problem in one pass. A diagnostic describes the
+/// platform-neutral style model, not any projected CSS, Flutter, DOM, or
+/// platform-specific output.
+///
+/// A diagnostic has two audiences. Tools should use [code], [severity], and
+/// [target] for programmatic handling. People should read [message], whose
+/// wording can improve over time without changing the meaning of [code].
 final class Diagnostic {
+  /// Creates a diagnostic with a stable code and a display message.
+  ///
+  /// The [code] should remain stable across releases. The [message] should be a
+  /// complete sentence that names the problem in style-core terms. Diagnostics
+  /// default to [DiagnosticSeverity.error] because structural style problems
+  /// should be treated as blocking unless the producer deliberately reports a
+  /// softer severity.
   const Diagnostic({
     required this.code,
     required this.message,
@@ -20,9 +75,28 @@ final class Diagnostic {
     this.target,
   });
 
+  /// The stable identifier for the problem that was found.
+  ///
+  /// Prefer values from [DiagnosticCodes]. Consumers should not parse
+  /// [message] when this value is sufficient.
   final String code;
+
+  /// The default importance of this diagnostic.
+  ///
+  /// Severity is advisory. A caller can still reject a design that reports only
+  /// warnings, or allow a design that reports errors, depending on the workflow.
   final DiagnosticSeverity severity;
+
+  /// The model object or source position associated with the problem.
+  ///
+  /// A diagnostic can omit the target when it describes a package-level problem
+  /// or when the producer does not have enough context to identify an owner.
   final DiagnosticTarget? target;
+
+  /// A human-readable explanation of the problem.
+  ///
+  /// Messages are written for display and may change as wording improves. Use
+  /// [code] for stable matching.
   final String message;
 
   @override
@@ -32,12 +106,31 @@ final class Diagnostic {
   }
 }
 
-/// The design entity a diagnostic points at.
+/// The style-core object or declaration associated with a diagnostic.
+///
+/// A target should point to the style declaration that caused the problem.
+/// Platform packages can translate the model later, but core diagnostics should
+/// not target CSS custom properties, Flutter widgets, DOM nodes, or generated
+/// output names.
 final class DiagnosticTarget {
+  /// Creates a target for a model object or source location.
+  ///
+  /// A useful target should normally provide [name], [location], or both. The
+  /// [kind] should be a stable lower-case noun such as `identifier`, `binding`,
+  /// `style`, or `policy`.
   const DiagnosticTarget({required this.kind, this.name, this.location});
 
+  /// The category of style-core object being reported.
   final String kind;
+
+  /// The user-authored name of the reported object.
+  ///
+  /// For named declarations this is usually an [Identifier.value]. The name is
+  /// optional because some diagnostics point at unnamed structures or at source
+  /// text that could not be read into a complete object.
   final String? name;
+
+  /// The source location of the reported object, when known.
   final DiagnosticLocation? location;
 
   @override
@@ -47,13 +140,32 @@ final class DiagnosticTarget {
   }
 }
 
-/// Optional source location metadata for diagnostics.
+/// Source coordinates for a diagnostic target.
+///
+/// Locations are optional because style declarations can be constructed
+/// directly in Dart, generated by tools, or loaded from files that provide
+/// different amounts of source information.
 final class DiagnosticLocation {
+  /// Creates source coordinates using the information available to the producer.
+  ///
+  /// [offset] is a zero-based UTF-16 code-unit offset into [source]. [line] and
+  /// [column] are one-based so they can be displayed directly in editor and
+  /// command-line diagnostics.
   const DiagnosticLocation({this.source, this.offset, this.line, this.column});
 
+  /// The file path, URI, or tool-defined source name.
   final String? source;
+
+  /// The zero-based UTF-16 code-unit offset in [source].
+  ///
+  /// Leave this unset when the source is not text, or when the producer only
+  /// knows line and column information.
   final int? offset;
+
+  /// The one-based line number in [source].
   final int? line;
+
+  /// The one-based column number in [source].
   final int? column;
 
   @override

--- a/lib/src/style/diagnostic.dart
+++ b/lib/src/style/diagnostic.dart
@@ -1,0 +1,70 @@
+/// Severity for a style-core diagnostic.
+enum DiagnosticSeverity { info, warning, error }
+
+/// Stable diagnostic code constants used by Odroe's style core.
+abstract final class DiagnosticCodes {
+  static const identifierEmpty = 'identifier.empty';
+  static const identifierEmptySegment = 'identifier.empty_segment';
+  static const identifierInvalidSegment = 'identifier.invalid_segment';
+  static const identifierDuplicate = 'identifier.duplicate';
+  static const identifierDuplicateIgnoringCase =
+      'identifier.duplicate_ignoring_case';
+}
+
+/// A structured diagnostic produced by validation or policy code.
+final class Diagnostic {
+  const Diagnostic({
+    required this.code,
+    required this.message,
+    this.severity = DiagnosticSeverity.error,
+    this.target,
+  });
+
+  final String code;
+  final DiagnosticSeverity severity;
+  final DiagnosticTarget? target;
+  final String message;
+
+  @override
+  String toString() {
+    final targetText = target == null ? '' : ' at $target';
+    return '[$severity] $code$targetText: $message';
+  }
+}
+
+/// The design entity a diagnostic points at.
+final class DiagnosticTarget {
+  const DiagnosticTarget({required this.kind, this.name, this.location});
+
+  final String kind;
+  final String? name;
+  final DiagnosticLocation? location;
+
+  @override
+  String toString() {
+    final nameText = name == null ? kind : '$kind `$name`';
+    return location == null ? nameText : '$nameText ($location)';
+  }
+}
+
+/// Optional source location metadata for diagnostics.
+final class DiagnosticLocation {
+  const DiagnosticLocation({this.source, this.offset, this.line, this.column});
+
+  final String? source;
+  final int? offset;
+  final int? line;
+  final int? column;
+
+  @override
+  String toString() {
+    final parts = <String>[
+      if (source != null) source!,
+      if (line != null) 'line $line',
+      if (column != null) 'column $column',
+      if (offset != null) 'offset $offset',
+    ];
+
+    return parts.join(', ');
+  }
+}

--- a/lib/src/style/diagnostic.dart
+++ b/lib/src/style/diagnostic.dart
@@ -171,7 +171,7 @@ final class DiagnosticLocation {
   @override
   String toString() {
     final parts = <String>[
-      if (source != null) source!,
+      ?source,
       if (line != null) 'line $line',
       if (column != null) 'column $column',
       if (offset != null) 'offset $offset',

--- a/lib/src/style/identifier.dart
+++ b/lib/src/style/identifier.dart
@@ -2,10 +2,42 @@ import 'diagnostic.dart';
 
 final _identifierSegmentPattern = RegExp(r'^[a-z][A-Za-z0-9_]*$');
 
-/// A stable dot-separated id for a design entity.
+/// A stable authoring name for a style-core declaration.
+///
+/// Identifiers name concepts in the design model, such as
+/// `color.action.fill`, `space.control_x`, or `button.tone`. They are not
+/// output names. Platform adapters may translate an identifier into a CSS
+/// custom property, a generated Dart constant, or another target-specific name,
+/// but the identifier remains the stable value used by core validation,
+/// diagnostics, and policy code.
+///
+/// Construction does not validate the string. Invalid identifiers need to be
+/// representable so tools can load incomplete design data and report structured
+/// diagnostics instead of throwing while reading.
 extension type const Identifier(String value) {
+  /// The path segments separated by dots in [value].
+  ///
+  /// Empty segments are preserved. For example, `color..action` produces
+  /// `['color', '', 'action']`, which lets [validate] report the exact problem.
   List<String> get segments => value.split('.');
 
+  /// Returns lexical diagnostics for this identifier.
+  ///
+  /// Valid identifiers are dot-separated paths whose segments start with a
+  /// lowercase letter and then contain only letters, digits, or underscores.
+  /// Examples include `color.action.fill`, `color.action.fillHover`, and
+  /// `space.control_x`.
+  ///
+  /// Invalid examples include `Color.Action`, `color..action`,
+  /// `color action`, and `color.action-fill`.
+  ///
+  /// It does not check whether the identifier is declared, duplicated, or valid
+  /// in a particular owner scope. Those checks require the object that owns the
+  /// identifiers, such as a binding, style, or design manifest.
+  ///
+  /// The optional `target` argument is copied to each reported
+  /// [Diagnostic.target]. When it is omitted, diagnostics point at this
+  /// identifier value with a target kind of `identifier`.
   List<Diagnostic> validate({DiagnosticTarget? target}) {
     final diagnosticTarget =
         target ?? DiagnosticTarget(kind: 'identifier', name: value);

--- a/lib/src/style/identifier.dart
+++ b/lib/src/style/identifier.dart
@@ -1,0 +1,55 @@
+import 'diagnostic.dart';
+
+final _identifierSegmentPattern = RegExp(r'^[a-z][A-Za-z0-9_]*$');
+
+/// A stable dot-separated id for a design entity.
+extension type const Identifier(String value) {
+  List<String> get segments => value.split('.');
+
+  List<Diagnostic> validate({DiagnosticTarget? target}) {
+    final diagnosticTarget =
+        target ?? DiagnosticTarget(kind: 'identifier', name: value);
+
+    if (value.isEmpty) {
+      return [
+        Diagnostic(
+          code: DiagnosticCodes.identifierEmpty,
+          target: diagnosticTarget,
+          message: 'Identifier must not be empty.',
+        ),
+      ];
+    }
+
+    final diagnostics = <Diagnostic>[];
+    final segments = this.segments;
+
+    for (var index = 0; index < segments.length; index += 1) {
+      final segment = segments[index];
+
+      if (segment.isEmpty) {
+        diagnostics.add(
+          Diagnostic(
+            code: DiagnosticCodes.identifierEmptySegment,
+            target: diagnosticTarget,
+            message: 'Identifier segment ${index + 1} must not be empty.',
+          ),
+        );
+        continue;
+      }
+
+      if (!_identifierSegmentPattern.hasMatch(segment)) {
+        diagnostics.add(
+          Diagnostic(
+            code: DiagnosticCodes.identifierInvalidSegment,
+            target: diagnosticTarget,
+            message:
+                'Identifier segment `$segment` must start with a lowercase '
+                'letter and contain only letters, digits, or underscores.',
+          ),
+        );
+      }
+    }
+
+    return diagnostics;
+  }
+}

--- a/lib/src/style/identifier_validation.dart
+++ b/lib/src/style/identifier_validation.dart
@@ -1,0 +1,50 @@
+import 'diagnostic.dart';
+import 'identifier.dart';
+
+/// Validates a group of identifiers and reports exact or case-insensitive
+/// duplicates in addition to per-identifier format diagnostics.
+///
+/// This is package-internal validation support for future design manifests and
+/// policy contexts. It is intentionally not exported from `package:odroe/style.dart`.
+List<Diagnostic> validateIdentifierSet(Iterable<Identifier> identifiers) {
+  final diagnostics = <Diagnostic>[];
+  final seen = <String, Identifier>{};
+  final seenIgnoringCase = <String, Identifier>{};
+
+  for (final identifier in identifiers) {
+    final target = DiagnosticTarget(kind: 'identifier', name: identifier.value);
+
+    diagnostics.addAll(identifier.validate(target: target));
+
+    final duplicate = seen[identifier.value];
+    if (duplicate != null) {
+      diagnostics.add(
+        Diagnostic(
+          code: DiagnosticCodes.identifierDuplicate,
+          target: target,
+          message: 'Identifier `${identifier.value}` is already defined.',
+        ),
+      );
+    } else {
+      seen[identifier.value] = identifier;
+    }
+
+    final folded = identifier.value.toLowerCase();
+    final caseDuplicate = seenIgnoringCase[folded];
+    if (caseDuplicate != null && caseDuplicate.value != identifier.value) {
+      diagnostics.add(
+        Diagnostic(
+          code: DiagnosticCodes.identifierDuplicateIgnoringCase,
+          target: target,
+          message:
+              'Identifier `${identifier.value}` conflicts with '
+              '`${caseDuplicate.value}` when compared case-insensitively.',
+        ),
+      );
+    } else {
+      seenIgnoringCase[folded] = identifier;
+    }
+  }
+
+  return diagnostics;
+}

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -5,4 +5,5 @@
 /// exported from here as they land.
 library;
 
-export 'src/style/core.dart';
+export 'src/style/diagnostic.dart';
+export 'src/style/identifier.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,3 +10,4 @@ environment:
 
 dev_dependencies:
   lints: ^6.1.0
+  test: ^1.31.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,3 +7,6 @@ issue_tracker: https://github.com/odroe/odroe/issues
 
 environment:
   sdk: ^3.10.0
+
+dev_dependencies:
+  lints: ^6.1.0

--- a/test/style/_utils.dart
+++ b/test/style/_utils.dart
@@ -1,0 +1,8 @@
+import 'package:odroe/style.dart';
+import 'package:test/test.dart';
+
+Matcher containsDiagnosticCode(String code) {
+  return contains(
+    isA<Diagnostic>().having((diagnostic) => diagnostic.code, 'code', code),
+  );
+}

--- a/test/style/identifier_test.dart
+++ b/test/style/identifier_test.dart
@@ -1,0 +1,47 @@
+import 'package:odroe/style.dart';
+
+void main() {
+  final identifier = Identifier('color.action.fill');
+  expect(identifier.value == 'color.action.fill', 'keeps the raw id value');
+  expect(
+    identifier.segments.join('/') == 'color/action/fill',
+    'splits identifier segments',
+  );
+  expect(Identifier('button.tone').validate().isEmpty, 'accepts button.tone');
+
+  expectCode(
+    Identifier('').validate(),
+    DiagnosticCodes.identifierEmpty,
+    'reports empty identifiers',
+  );
+  expectCode(
+    Identifier('color..action').validate(),
+    DiagnosticCodes.identifierEmptySegment,
+    'reports empty segments',
+  );
+  expectCode(
+    Identifier('Color.Action').validate(),
+    DiagnosticCodes.identifierInvalidSegment,
+    'reports uppercase starts',
+  );
+  expectCode(
+    Identifier('color action').validate(),
+    DiagnosticCodes.identifierInvalidSegment,
+    'reports whitespace',
+  );
+  expectCode(
+    Identifier('color.action-fill').validate(),
+    DiagnosticCodes.identifierInvalidSegment,
+    'reports hyphenated segments',
+  );
+}
+
+void expect(bool condition, String message) {
+  if (!condition) {
+    throw StateError(message);
+  }
+}
+
+void expectCode(List<Diagnostic> diagnostics, String code, String message) {
+  expect(diagnostics.any((diagnostic) => diagnostic.code == code), message);
+}

--- a/test/style/identifier_test.dart
+++ b/test/style/identifier_test.dart
@@ -1,6 +1,8 @@
 import 'package:odroe/style.dart';
 import 'package:test/test.dart';
 
+import '_utils.dart';
+
 void main() {
   test('keeps the raw identifier value', () {
     const identifier = Identifier('color.action.fill');
@@ -40,10 +42,4 @@ void main() {
       containsDiagnosticCode(DiagnosticCodes.identifierInvalidSegment),
     );
   });
-}
-
-Matcher containsDiagnosticCode(String code) {
-  return contains(
-    isA<Diagnostic>().having((diagnostic) => diagnostic.code, 'code', code),
-  );
 }

--- a/test/style/identifier_test.dart
+++ b/test/style/identifier_test.dart
@@ -1,47 +1,49 @@
 import 'package:odroe/style.dart';
+import 'package:test/test.dart';
 
 void main() {
-  final identifier = Identifier('color.action.fill');
-  expect(identifier.value == 'color.action.fill', 'keeps the raw id value');
-  expect(
-    identifier.segments.join('/') == 'color/action/fill',
-    'splits identifier segments',
-  );
-  expect(Identifier('button.tone').validate().isEmpty, 'accepts button.tone');
+  test('keeps the raw identifier value', () {
+    const identifier = Identifier('color.action.fill');
 
-  expectCode(
-    Identifier('').validate(),
-    DiagnosticCodes.identifierEmpty,
-    'reports empty identifiers',
-  );
-  expectCode(
-    Identifier('color..action').validate(),
-    DiagnosticCodes.identifierEmptySegment,
-    'reports empty segments',
-  );
-  expectCode(
-    Identifier('Color.Action').validate(),
-    DiagnosticCodes.identifierInvalidSegment,
-    'reports uppercase starts',
-  );
-  expectCode(
-    Identifier('color action').validate(),
-    DiagnosticCodes.identifierInvalidSegment,
-    'reports whitespace',
-  );
-  expectCode(
-    Identifier('color.action-fill').validate(),
-    DiagnosticCodes.identifierInvalidSegment,
-    'reports hyphenated segments',
-  );
+    expect(identifier.value, 'color.action.fill');
+  });
+
+  test('splits dot-separated segments', () {
+    const identifier = Identifier('color.action.fill');
+
+    expect(identifier.segments, ['color', 'action', 'fill']);
+  });
+
+  test('accepts valid identifiers', () {
+    expect(const Identifier('button.tone').validate(), isEmpty);
+  });
+
+  test('reports invalid identifier formats', () {
+    expect(
+      const Identifier('').validate(),
+      containsDiagnosticCode(DiagnosticCodes.identifierEmpty),
+    );
+    expect(
+      const Identifier('color..action').validate(),
+      containsDiagnosticCode(DiagnosticCodes.identifierEmptySegment),
+    );
+    expect(
+      const Identifier('Color.Action').validate(),
+      containsDiagnosticCode(DiagnosticCodes.identifierInvalidSegment),
+    );
+    expect(
+      const Identifier('color action').validate(),
+      containsDiagnosticCode(DiagnosticCodes.identifierInvalidSegment),
+    );
+    expect(
+      const Identifier('color.action-fill').validate(),
+      containsDiagnosticCode(DiagnosticCodes.identifierInvalidSegment),
+    );
+  });
 }
 
-void expect(bool condition, String message) {
-  if (!condition) {
-    throw StateError(message);
-  }
-}
-
-void expectCode(List<Diagnostic> diagnostics, String code, String message) {
-  expect(diagnostics.any((diagnostic) => diagnostic.code == code), message);
+Matcher containsDiagnosticCode(String code) {
+  return contains(
+    isA<Diagnostic>().having((diagnostic) => diagnostic.code, 'code', code),
+  );
 }

--- a/test/style/src/identifier_validation_test.dart
+++ b/test/style/src/identifier_validation_test.dart
@@ -1,0 +1,31 @@
+import 'package:odroe/src/style/identifier_validation.dart';
+import 'package:odroe/style.dart';
+
+void main() {
+  final duplicateDiagnostics = validateIdentifierSet([
+    Identifier('color.action.fill'),
+    Identifier('color.action.fill'),
+    Identifier('Color.Action.Fill'),
+  ]);
+
+  expectCode(
+    duplicateDiagnostics,
+    DiagnosticCodes.identifierDuplicate,
+    'reports exact duplicates',
+  );
+  expectCode(
+    duplicateDiagnostics,
+    DiagnosticCodes.identifierDuplicateIgnoringCase,
+    'reports case-insensitive duplicates',
+  );
+}
+
+void expect(bool condition, String message) {
+  if (!condition) {
+    throw StateError(message);
+  }
+}
+
+void expectCode(List<Diagnostic> diagnostics, String code, String message) {
+  expect(diagnostics.any((diagnostic) => diagnostic.code == code), message);
+}

--- a/test/style/src/identifier_validation_test.dart
+++ b/test/style/src/identifier_validation_test.dart
@@ -1,31 +1,28 @@
 import 'package:odroe/src/style/identifier_validation.dart';
 import 'package:odroe/style.dart';
+import 'package:test/test.dart';
 
 void main() {
-  final duplicateDiagnostics = validateIdentifierSet([
-    Identifier('color.action.fill'),
-    Identifier('color.action.fill'),
-    Identifier('Color.Action.Fill'),
-  ]);
+  test('reports duplicate identifiers in one validation set', () {
+    final duplicateDiagnostics = validateIdentifierSet([
+      Identifier('color.action.fill'),
+      Identifier('color.action.fill'),
+      Identifier('Color.Action.Fill'),
+    ]);
 
-  expectCode(
-    duplicateDiagnostics,
-    DiagnosticCodes.identifierDuplicate,
-    'reports exact duplicates',
-  );
-  expectCode(
-    duplicateDiagnostics,
-    DiagnosticCodes.identifierDuplicateIgnoringCase,
-    'reports case-insensitive duplicates',
-  );
+    expect(
+      duplicateDiagnostics,
+      containsDiagnosticCode(DiagnosticCodes.identifierDuplicate),
+    );
+    expect(
+      duplicateDiagnostics,
+      containsDiagnosticCode(DiagnosticCodes.identifierDuplicateIgnoringCase),
+    );
+  });
 }
 
-void expect(bool condition, String message) {
-  if (!condition) {
-    throw StateError(message);
-  }
-}
-
-void expectCode(List<Diagnostic> diagnostics, String code, String message) {
-  expect(diagnostics.any((diagnostic) => diagnostic.code == code), message);
+Matcher containsDiagnosticCode(String code) {
+  return contains(
+    isA<Diagnostic>().having((diagnostic) => diagnostic.code, 'code', code),
+  );
 }

--- a/test/style/src/identifier_validation_test.dart
+++ b/test/style/src/identifier_validation_test.dart
@@ -2,6 +2,8 @@ import 'package:odroe/src/style/identifier_validation.dart';
 import 'package:odroe/style.dart';
 import 'package:test/test.dart';
 
+import '../_utils.dart';
+
 void main() {
   test('reports duplicate identifiers in one validation set', () {
     final duplicateDiagnostics = validateIdentifierSet([
@@ -19,10 +21,4 @@ void main() {
       containsDiagnosticCode(DiagnosticCodes.identifierDuplicateIgnoringCase),
     );
   });
-}
-
-Matcher containsDiagnosticCode(String code) {
-  return contains(
-    isA<Diagnostic>().having((diagnostic) => diagnostic.code, 'code', code),
-  );
 }

--- a/test/style_entrypoint_test.dart
+++ b/test/style_entrypoint_test.dart
@@ -1,5 +1,0 @@
-// ignore_for_file: unused_import
-
-import 'package:odroe/style.dart';
-
-void main() {}


### PR DESCRIPTION
## Summary

- Adds the platform-neutral style identifier and diagnostics foundation for `package:odroe/style.dart`.
- Removes the temporary style core export shim and exports the concrete style core modules directly.
- Adds Dart linting, API documentation enforcement, package:test-based tests, and a Dart validation workflow.

## Impact

This establishes the first real style-core API surface after the public entrypoint work. `Identifier` now supports lexical diagnostics, diagnostic codes are stable handles for tools, and owner-scope duplicate checks are kept internal until manifest or binding owners exist.

Closes #40

## Validation

- `dart pub get`
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze .`
- `dart test`
- `dart doc --dry-run .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public identifier validation with clear diagnostics for empty, invalid, and duplicate names.
  * Added diagnostic reporting types for consistent error, warning, and info messages.
  * Expanded the public style API to expose identifier and diagnostic support.

* **Bug Fixes**
  * Improved handling of dot-separated names, including empty segments and case-insensitive duplicates.

* **Tests**
  * Added coverage for identifier validation and duplicate detection.

* **Chores**
  * Added automated Dart formatting, analysis, testing, and documentation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->