### PR TITLE
feat: add style appearance values

### DIFF
--- a/lib/src/style/appearance.dart
+++ b/lib/src/style/appearance.dart
@@ -1,0 +1,328 @@
+import 'binding.dart';
+import 'identifier.dart';
+
+/// A partial visual declaration that can be reused and merged.
+///
+/// An appearance describes what something should look like without saying how
+/// any platform should render it. It is the common value that later `Style`
+/// declarations will use for roots, parts, and conditional cases.
+///
+/// ```dart
+/// const actionFill = Term<ColorValue>(Identifier('color.action.fill'));
+/// const controlRadius = Term<Unit>(Identifier('radius.control'));
+///
+/// final control = Appearance(
+///   surface: Surface(
+///     fill: AppearanceValue.term(actionFill),
+///     radius: AppearanceValue.term(controlRadius),
+///   ),
+///   metrics: Metrics(
+///     padding: Insets.symmetric(
+///       x: AppearanceValue.literal(Unit.px(16)),
+///       y: AppearanceValue.literal(Unit.px(8)),
+///     ),
+///   ),
+/// );
+/// ```
+///
+/// Appearances are intentionally visual-only. Gestures, navigation, semantic
+/// actions, routing, and application behavior belong outside this model.
+final class Appearance {
+  /// Creates an appearance from optional visual facets.
+  const Appearance({this.surface, this.content, this.metrics});
+
+  /// Surface-facing visual properties such as fills, strokes, and radius.
+  final Surface? surface;
+
+  /// Content-facing visual properties such as text and icon color.
+  final Content? content;
+
+  /// Size and spacing properties.
+  final Metrics? metrics;
+
+  /// Merges this appearance with [later].
+  ///
+  /// Merge is property-based, not cascade-based. If [later] provides a facet,
+  /// that facet is merged with the existing facet. Inside each facet, non-null
+  /// properties from [later] replace earlier values and null properties leave
+  /// earlier values unchanged.
+  Appearance merge(Appearance later) {
+    return Appearance(
+      surface: switch ((surface, later.surface)) {
+        (final current?, final next?) => current.merge(next),
+        (final current?, null) => current,
+        (null, final next?) => next,
+        _ => null,
+      },
+      content: switch ((content, later.content)) {
+        (final current?, final next?) => current.merge(next),
+        (final current?, null) => current,
+        (null, final next?) => next,
+        _ => null,
+      },
+      metrics: switch ((metrics, later.metrics)) {
+        (final current?, final next?) => current.merge(next),
+        (final current?, null) => current,
+        (null, final next?) => next,
+        _ => null,
+      },
+    );
+  }
+}
+
+/// The visual treatment of a surface.
+///
+/// Surface properties describe the container plane: its fill, outline, radius,
+/// and elevation. They deliberately avoid CSS boxes, Flutter decorations, and
+/// Material components.
+final class Surface {
+  /// Creates a partial surface declaration.
+  const Surface({this.fill, this.stroke, this.radius, this.elevation});
+
+  /// The surface fill color.
+  final AppearanceValue<ColorValue>? fill;
+
+  /// The stroke or border color for the surface.
+  final AppearanceValue<ColorValue>? stroke;
+
+  /// The corner radius or shape radius for the surface.
+  final AppearanceValue<Unit>? radius;
+
+  /// The platform-neutral elevation role or amount.
+  final AppearanceValue<Unit>? elevation;
+
+  /// Returns this surface with non-null properties from [later] applied.
+  Surface merge(Surface later) {
+    return Surface(
+      fill: later.fill ?? fill,
+      stroke: later.stroke ?? stroke,
+      radius: later.radius ?? radius,
+      elevation: later.elevation ?? elevation,
+    );
+  }
+}
+
+/// The visual treatment of content inside a surface.
+///
+/// Content properties describe visible children such as labels and icons. They
+/// do not describe the child widgets, DOM nodes, accessibility labels, or
+/// semantic actions that may eventually use these values.
+final class Content {
+  /// Creates a partial content declaration.
+  const Content({this.color, this.text, this.icon, this.opacity});
+
+  /// The foreground color for text or icons.
+  final AppearanceValue<ColorValue>? color;
+
+  /// The semantic text role to use for labels.
+  final AppearanceValue<Identifier>? text;
+
+  /// The semantic icon role to use for icons.
+  final AppearanceValue<Identifier>? icon;
+
+  /// The opacity applied to content.
+  final AppearanceValue<double>? opacity;
+
+  /// Returns this content with non-null properties from [later] applied.
+  Content merge(Content later) {
+    return Content(
+      color: later.color ?? color,
+      text: later.text ?? text,
+      icon: later.icon ?? icon,
+      opacity: later.opacity ?? opacity,
+    );
+  }
+}
+
+/// Platform-neutral spacing and size values.
+///
+/// Metrics describe the space a visual object asks for. They are not layout
+/// algorithms and do not decide flex, grid, constraints, or widget structure.
+final class Metrics {
+  /// Creates a partial metrics declaration.
+  const Metrics({
+    this.padding,
+    this.gap,
+    this.width,
+    this.height,
+    this.minWidth,
+    this.minHeight,
+    this.maxWidth,
+    this.maxHeight,
+  });
+
+  /// Space between the outside edge and content.
+  final Insets? padding;
+
+  /// Space between repeated children.
+  final AppearanceValue<Unit>? gap;
+
+  /// The preferred width.
+  final AppearanceValue<Unit>? width;
+
+  /// The preferred height.
+  final AppearanceValue<Unit>? height;
+
+  /// The minimum width.
+  final AppearanceValue<Unit>? minWidth;
+
+  /// The minimum height.
+  final AppearanceValue<Unit>? minHeight;
+
+  /// The maximum width.
+  final AppearanceValue<Unit>? maxWidth;
+
+  /// The maximum height.
+  final AppearanceValue<Unit>? maxHeight;
+
+  /// Returns this metrics declaration with non-null properties from [later]
+  /// applied.
+  Metrics merge(Metrics later) {
+    return Metrics(
+      padding: switch ((padding, later.padding)) {
+        (final current?, final next?) => current.merge(next),
+        (final current?, null) => current,
+        (null, final next?) => next,
+        _ => null,
+      },
+      gap: later.gap ?? gap,
+      width: later.width ?? width,
+      height: later.height ?? height,
+      minWidth: later.minWidth ?? minWidth,
+      minHeight: later.minHeight ?? minHeight,
+      maxWidth: later.maxWidth ?? maxWidth,
+      maxHeight: later.maxHeight ?? maxHeight,
+    );
+  }
+}
+
+/// A literal appearance value or a reference to a vocabulary term.
+///
+/// Appearance declarations can use concrete values directly, or defer the value
+/// to a [Binding] by referencing a [Term]. Resolution is intentionally not part
+/// of this type; a later resolver will choose a binding and replace term
+/// references with concrete values.
+///
+/// ```dart
+/// const fill = AppearanceValue.literal(ColorValue.hex(0xff006adc));
+/// const fillTerm = Term<ColorValue>(Identifier('color.action.fill'));
+/// const referencedFill = AppearanceValue.term(fillTerm);
+/// ```
+final class AppearanceValue<T> {
+  /// Creates a concrete appearance value.
+  const AppearanceValue.literal(T value) : literal = value, term = null;
+
+  /// Creates an appearance value that will be read from a binding later.
+  const AppearanceValue.term(Term<T> this.term) : literal = null;
+
+  /// The concrete value, when this is a literal value.
+  final T? literal;
+
+  /// The referenced term, when this value is binding-backed.
+  final Term<T>? term;
+
+  /// Whether this value stores a literal value.
+  bool get isLiteral => term == null;
+
+  /// Whether this value references a [Term].
+  bool get isTerm => term != null;
+}
+
+/// A platform-neutral 32-bit ARGB color.
+///
+/// The integer layout matches `0xAARRGGBB`. This value does not depend on
+/// Flutter's `Color`, CSS color strings, or browser parsing rules.
+final class ColorValue {
+  /// Creates a color from a 32-bit ARGB integer.
+  const ColorValue.hex(this.argb)
+    : assert(argb >= 0),
+      assert(argb <= 0xffffffff);
+
+  /// The `0xAARRGGBB` color value.
+  final int argb;
+
+  @override
+  bool operator ==(Object other) {
+    return other is ColorValue && other.argb == argb;
+  }
+
+  @override
+  int get hashCode => argb.hashCode;
+}
+
+/// The unit used by a [Unit] value.
+enum UnitKind {
+  /// A logical pixel-like unit.
+  ///
+  /// Platform adapters decide how this maps to their own coordinate systems.
+  px,
+}
+
+/// A platform-neutral scalar size.
+///
+/// Units are declaration values, not layout constraints. They can describe
+/// spacing, radius, gaps, and other visual metrics without naming a rendering
+/// toolkit.
+final class Unit {
+  /// Creates a logical pixel-like size.
+  const Unit.px(this.value) : kind = UnitKind.px;
+
+  /// The numeric amount.
+  final double value;
+
+  /// The unit used by [value].
+  final UnitKind kind;
+
+  @override
+  bool operator ==(Object other) {
+    return other is Unit && other.value == value && other.kind == kind;
+  }
+
+  @override
+  int get hashCode => Object.hash(value, kind);
+}
+
+/// Four-sided spacing used by [Metrics.padding].
+///
+/// Each side is optional so padding can participate in appearance merging.
+/// Later insets override only the sides they set.
+final class Insets {
+  /// Creates insets with explicit sides.
+  const Insets.only({this.top, this.right, this.bottom, this.left});
+
+  /// Creates equal insets on every side.
+  const Insets.all(AppearanceValue<Unit> value)
+    : top = value,
+      right = value,
+      bottom = value,
+      left = value;
+
+  /// Creates horizontal and vertical insets.
+  const Insets.symmetric({AppearanceValue<Unit>? x, AppearanceValue<Unit>? y})
+    : top = y,
+      right = x,
+      bottom = y,
+      left = x;
+
+  /// The top inset.
+  final AppearanceValue<Unit>? top;
+
+  /// The right inset.
+  final AppearanceValue<Unit>? right;
+
+  /// The bottom inset.
+  final AppearanceValue<Unit>? bottom;
+
+  /// The left inset.
+  final AppearanceValue<Unit>? left;
+
+  /// Returns this inset set with non-null sides from [later] applied.
+  Insets merge(Insets later) {
+    return Insets.only(
+      top: later.top ?? top,
+      right: later.right ?? right,
+      bottom: later.bottom ?? bottom,
+      left: later.left ?? left,
+    );
+  }
+}

--- a/lib/src/style/appearance.dart
+++ b/lib/src/style/appearance.dart
@@ -9,7 +9,7 @@ import 'mergeable.dart';
 /// declarations will use for roots, parts, and conditional cases.
 ///
 /// ```dart
-/// const actionFill = Term<ColorValue>(Identifier('color.action.fill'));
+/// const actionFill = Term<Color>(Identifier('color.action.fill'));
 /// const controlRadius = Term<Unit>(Identifier('radius.control'));
 ///
 /// final control = Appearance(
@@ -67,10 +67,10 @@ final class Surface implements Mergeable<Surface> {
   const Surface({this.fill, this.stroke, this.radius, this.elevation});
 
   /// The surface fill color.
-  final Property<ColorValue>? fill;
+  final Property<Color>? fill;
 
   /// The stroke or border color for the surface.
-  final Property<ColorValue>? stroke;
+  final Property<Color>? stroke;
 
   /// The corner radius or shape radius for the surface.
   final Property<Unit>? radius;
@@ -100,7 +100,7 @@ final class Content implements Mergeable<Content> {
   const Content({this.color, this.text, this.icon, this.opacity});
 
   /// The foreground color for text or icons.
-  final Property<ColorValue>? color;
+  final Property<Color>? color;
 
   /// The semantic text role to use for labels.
   final Property<Identifier>? text;
@@ -190,13 +190,13 @@ final class Metrics implements Mergeable<Metrics> {
 /// Use a literal when the declaration owns the exact value:
 ///
 /// ```dart
-/// const surface = Surface(fill: .literal(ColorValue.hex(0xff006adc)));
+/// const surface = Surface(fill: .literal(Color(0xff006adc)));
 /// ```
 ///
 /// Use a term when the declaration should follow a shared binding:
 ///
 /// ```dart
-/// const fillTerm = Term<ColorValue>(Identifier('color.action.fill'));
+/// const fillTerm = Term<Color>(Identifier('color.action.fill'));
 ///
 /// const surface = Surface(fill: .term(fillTerm));
 /// ```
@@ -235,26 +235,136 @@ final class TermProperty<T> extends Property<T> {
   final Term<T> term;
 }
 
-/// A platform-neutral 32-bit ARGB color.
+/// A platform-neutral color value.
 ///
-/// The integer layout matches `0xAARRGGBB`. This value does not depend on
-/// Flutter's `Color`, CSS color strings, or browser parsing rules.
-final class ColorValue {
-  /// Creates a color from a 32-bit ARGB integer.
-  const ColorValue.hex(this.argb)
-    : assert(argb >= 0),
-      assert(argb <= 0xffffffff);
+/// The default constructor accepts the same `0xAARRGGBB` packed integer shape
+/// used by `dart:ui.Color`, without depending on Flutter's `dart:ui` library.
+/// Channels are stored as floating-point components so declarations can keep
+/// their authored values and convert back to an ARGB integer when needed.
+///
+/// ```dart
+/// const blue = Color(0xff42a5f5);
+/// const sameBlue = Color.fromARGB(0xff, 0x42, 0xa5, 0xf5);
+/// ```
+final class Color {
+  /// Creates an sRGB color from the lower 32 bits of [value].
+  ///
+  /// The bits are interpreted as `0xAARRGGBB`: alpha in bits 24-31, red in
+  /// bits 16-23, green in bits 8-15, and blue in bits 0-7.
+  const Color(int value)
+    : this._fromARGB(
+        (value >> 24) & 0xff,
+        (value >> 16) & 0xff,
+        (value >> 8) & 0xff,
+        value & 0xff,
+      );
 
-  /// The `0xAARRGGBB` color value.
-  final int argb;
+  /// Creates a color from floating-point channel values.
+  ///
+  /// The conventional range for each channel is `0.0` to `1.0`. Values outside
+  /// that range are preserved in the declaration and clamped only when
+  /// converted with [toARGB32].
+  const Color.from({
+    required double alpha,
+    required double red,
+    required double green,
+    required double blue,
+  }) : a = alpha,
+       r = red,
+       g = green,
+       b = blue;
 
-  @override
-  bool operator ==(Object other) {
-    return other is ColorValue && other.argb == argb;
+  /// Creates an sRGB color from integer alpha, red, green, and blue channels.
+  ///
+  /// Only the lower 8 bits of each channel are used, matching
+  /// `dart:ui.Color.fromARGB`.
+  const Color.fromARGB(int a, int r, int g, int b) : this._fromARGB(a, r, g, b);
+
+  /// Creates a color from red, green, blue, and opacity channels.
+  ///
+  /// Only the lower 8 bits of the red, green, and blue channels are used.
+  /// The conventional range for [opacity] is `0.0` to `1.0`.
+  const Color.fromRGBO(int r, int g, int b, double opacity)
+    : a = opacity,
+      r = (r & 0xff) / 255,
+      g = (g & 0xff) / 255,
+      b = (b & 0xff) / 255;
+
+  const Color._fromARGB(int alpha, int red, int green, int blue)
+    : this._fromRGBO(red, green, blue, (alpha & 0xff) / 255);
+
+  const Color._fromRGBO(int red, int green, int blue, double opacity)
+    : a = opacity,
+      r = (red & 0xff) / 255,
+      g = (green & 0xff) / 255,
+      b = (blue & 0xff) / 255;
+
+  /// The alpha channel as a floating-point component.
+  final double a;
+
+  /// The red channel as a floating-point component.
+  final double r;
+
+  /// The green channel as a floating-point component.
+  final double g;
+
+  /// The blue channel as a floating-point component.
+  final double b;
+
+  /// Returns a copy with the provided channels replaced.
+  Color withValues({double? alpha, double? red, double? green, double? blue}) {
+    return Color.from(
+      alpha: alpha ?? a,
+      red: red ?? r,
+      green: green ?? g,
+      blue: blue ?? b,
+    );
+  }
+
+  /// Returns this color as a packed `0xAARRGGBB` integer.
+  ///
+  /// Channel values are rounded to the nearest 8-bit integer and clamped to the
+  /// range `0..255`.
+  int toARGB32() {
+    return _floatToInt8(a) << 24 |
+        _floatToInt8(r) << 16 |
+        _floatToInt8(g) << 8 |
+        _floatToInt8(b);
+  }
+
+  static int _floatToInt8(double value) {
+    final scaled = (value * 255.0).round();
+
+    if (scaled < 0) {
+      return 0;
+    }
+    if (scaled > 255) {
+      return 255;
+    }
+    return scaled;
   }
 
   @override
-  int get hashCode => argb.hashCode;
+  bool operator ==(Object other) {
+    return other is Color &&
+        other.a == a &&
+        other.r == r &&
+        other.g == g &&
+        other.b == b;
+  }
+
+  @override
+  int get hashCode => Object.hash(a, r, g, b);
+
+  @override
+  String toString() {
+    return 'Color('
+        'alpha: ${a.toStringAsFixed(4)}, '
+        'red: ${r.toStringAsFixed(4)}, '
+        'green: ${g.toStringAsFixed(4)}, '
+        'blue: ${b.toStringAsFixed(4)}'
+        ')';
+  }
 }
 
 /// The unit used by a [Unit] value.

--- a/lib/src/style/appearance.dart
+++ b/lib/src/style/appearance.dart
@@ -1,4 +1,6 @@
 import 'binding.dart';
+import 'color.dart';
+import 'dimension.dart';
 import 'identifier.dart';
 import 'mergeable.dart';
 
@@ -10,7 +12,7 @@ import 'mergeable.dart';
 ///
 /// ```dart
 /// const actionFill = Term<Color>(Identifier('color.action.fill'));
-/// const controlRadius = Term<Unit>(Identifier('radius.control'));
+/// const controlRadius = Term<Dimension>(Identifier('radius.control'));
 ///
 /// final control = Appearance(
 ///   surface: Surface(
@@ -19,8 +21,8 @@ import 'mergeable.dart';
 ///   ),
 ///   metrics: Metrics(
 ///     padding: Insets.symmetric(
-///       x: .literal(Unit.px(16)),
-///       y: .literal(Unit.px(8)),
+///       x: .literal(16.px),
+///       y: .literal(8.px),
 ///     ),
 ///   ),
 /// );
@@ -73,10 +75,10 @@ final class Surface implements Mergeable<Surface> {
   final Property<Color>? stroke;
 
   /// The corner radius or shape radius for the surface.
-  final Property<Unit>? radius;
+  final Property<Dimension>? radius;
 
   /// The platform-neutral elevation role or amount.
-  final Property<Unit>? elevation;
+  final Property<Dimension>? elevation;
 
   /// Returns this surface with non-null properties from [later] applied.
   @override
@@ -144,25 +146,25 @@ final class Metrics implements Mergeable<Metrics> {
   final Insets? padding;
 
   /// Space between repeated children.
-  final Property<Unit>? gap;
+  final Property<Dimension>? gap;
 
   /// The preferred width.
-  final Property<Unit>? width;
+  final Property<Dimension>? width;
 
   /// The preferred height.
-  final Property<Unit>? height;
+  final Property<Dimension>? height;
 
   /// The minimum width.
-  final Property<Unit>? minWidth;
+  final Property<Dimension>? minWidth;
 
   /// The minimum height.
-  final Property<Unit>? minHeight;
+  final Property<Dimension>? minHeight;
 
   /// The maximum width.
-  final Property<Unit>? maxWidth;
+  final Property<Dimension>? maxWidth;
 
   /// The maximum height.
-  final Property<Unit>? maxHeight;
+  final Property<Dimension>? maxHeight;
 
   /// Returns this metrics declaration with non-null properties from [later]
   /// applied.
@@ -235,170 +237,6 @@ final class TermProperty<T> extends Property<T> {
   final Term<T> term;
 }
 
-/// A platform-neutral color value.
-///
-/// The default constructor accepts the same `0xAARRGGBB` packed integer shape
-/// used by `dart:ui.Color`, without depending on Flutter's `dart:ui` library.
-/// Channels are stored as floating-point components so declarations can keep
-/// their authored values and convert back to an ARGB integer when needed.
-///
-/// ```dart
-/// const blue = Color(0xff42a5f5);
-/// const sameBlue = Color.fromARGB(0xff, 0x42, 0xa5, 0xf5);
-/// ```
-final class Color {
-  /// Creates an sRGB color from the lower 32 bits of [value].
-  ///
-  /// The bits are interpreted as `0xAARRGGBB`: alpha in bits 24-31, red in
-  /// bits 16-23, green in bits 8-15, and blue in bits 0-7.
-  const Color(int value)
-    : this._fromARGB(
-        (value >> 24) & 0xff,
-        (value >> 16) & 0xff,
-        (value >> 8) & 0xff,
-        value & 0xff,
-      );
-
-  /// Creates a color from floating-point channel values.
-  ///
-  /// The conventional range for each channel is `0.0` to `1.0`. Values outside
-  /// that range are preserved in the declaration and clamped only when
-  /// converted with [toARGB32].
-  const Color.from({
-    required double alpha,
-    required double red,
-    required double green,
-    required double blue,
-  }) : a = alpha,
-       r = red,
-       g = green,
-       b = blue;
-
-  /// Creates an sRGB color from integer alpha, red, green, and blue channels.
-  ///
-  /// Only the lower 8 bits of each channel are used, matching
-  /// `dart:ui.Color.fromARGB`.
-  const Color.fromARGB(int a, int r, int g, int b) : this._fromARGB(a, r, g, b);
-
-  /// Creates a color from red, green, blue, and opacity channels.
-  ///
-  /// Only the lower 8 bits of the red, green, and blue channels are used.
-  /// The conventional range for [opacity] is `0.0` to `1.0`.
-  const Color.fromRGBO(int r, int g, int b, double opacity)
-    : a = opacity,
-      r = (r & 0xff) / 255,
-      g = (g & 0xff) / 255,
-      b = (b & 0xff) / 255;
-
-  const Color._fromARGB(int alpha, int red, int green, int blue)
-    : this._fromRGBO(red, green, blue, (alpha & 0xff) / 255);
-
-  const Color._fromRGBO(int red, int green, int blue, double opacity)
-    : a = opacity,
-      r = (red & 0xff) / 255,
-      g = (green & 0xff) / 255,
-      b = (blue & 0xff) / 255;
-
-  /// The alpha channel as a floating-point component.
-  final double a;
-
-  /// The red channel as a floating-point component.
-  final double r;
-
-  /// The green channel as a floating-point component.
-  final double g;
-
-  /// The blue channel as a floating-point component.
-  final double b;
-
-  /// Returns a copy with the provided channels replaced.
-  Color withValues({double? alpha, double? red, double? green, double? blue}) {
-    return Color.from(
-      alpha: alpha ?? a,
-      red: red ?? r,
-      green: green ?? g,
-      blue: blue ?? b,
-    );
-  }
-
-  /// Returns this color as a packed `0xAARRGGBB` integer.
-  ///
-  /// Channel values are rounded to the nearest 8-bit integer and clamped to the
-  /// range `0..255`.
-  int toARGB32() {
-    return _floatToInt8(a) << 24 |
-        _floatToInt8(r) << 16 |
-        _floatToInt8(g) << 8 |
-        _floatToInt8(b);
-  }
-
-  static int _floatToInt8(double value) {
-    final scaled = (value * 255.0).round();
-
-    if (scaled < 0) {
-      return 0;
-    }
-    if (scaled > 255) {
-      return 255;
-    }
-    return scaled;
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return other is Color &&
-        other.a == a &&
-        other.r == r &&
-        other.g == g &&
-        other.b == b;
-  }
-
-  @override
-  int get hashCode => Object.hash(a, r, g, b);
-
-  @override
-  String toString() {
-    return 'Color('
-        'alpha: ${a.toStringAsFixed(4)}, '
-        'red: ${r.toStringAsFixed(4)}, '
-        'green: ${g.toStringAsFixed(4)}, '
-        'blue: ${b.toStringAsFixed(4)}'
-        ')';
-  }
-}
-
-/// The unit used by a [Unit] value.
-enum UnitKind {
-  /// A logical pixel-like unit.
-  ///
-  /// Platform adapters decide how this maps to their own coordinate systems.
-  px,
-}
-
-/// A platform-neutral scalar size.
-///
-/// Units are declaration values, not layout constraints. They can describe
-/// spacing, radius, gaps, and other visual metrics without naming a rendering
-/// toolkit.
-final class Unit {
-  /// Creates a logical pixel-like size.
-  const Unit.px(this.value) : kind = UnitKind.px;
-
-  /// The numeric amount.
-  final double value;
-
-  /// The unit used by [value].
-  final UnitKind kind;
-
-  @override
-  bool operator ==(Object other) {
-    return other is Unit && other.value == value && other.kind == kind;
-  }
-
-  @override
-  int get hashCode => Object.hash(value, kind);
-}
-
 /// Four-sided spacing used by [Metrics.padding].
 ///
 /// Each side is optional so padding can participate in appearance merging.
@@ -408,30 +246,30 @@ final class Insets implements Mergeable<Insets> {
   const Insets.only({this.top, this.right, this.bottom, this.left});
 
   /// Creates equal insets on every side.
-  const Insets.all(Property<Unit> value)
+  const Insets.all(Property<Dimension> value)
     : top = value,
       right = value,
       bottom = value,
       left = value;
 
   /// Creates horizontal and vertical insets.
-  const Insets.symmetric({Property<Unit>? x, Property<Unit>? y})
+  const Insets.symmetric({Property<Dimension>? x, Property<Dimension>? y})
     : top = y,
       right = x,
       bottom = y,
       left = x;
 
   /// The top inset.
-  final Property<Unit>? top;
+  final Property<Dimension>? top;
 
   /// The right inset.
-  final Property<Unit>? right;
+  final Property<Dimension>? right;
 
   /// The bottom inset.
-  final Property<Unit>? bottom;
+  final Property<Dimension>? bottom;
 
   /// The left inset.
-  final Property<Unit>? left;
+  final Property<Dimension>? left;
 
   /// Returns this inset set with non-null sides from [later] applied.
   @override

--- a/lib/src/style/appearance.dart
+++ b/lib/src/style/appearance.dart
@@ -1,5 +1,6 @@
 import 'binding.dart';
 import 'identifier.dart';
+import 'mergeable.dart';
 
 /// A partial visual declaration that can be reused and merged.
 ///
@@ -27,7 +28,7 @@ import 'identifier.dart';
 ///
 /// Appearances are intentionally visual-only. Gestures, navigation, semantic
 /// actions, routing, and application behavior belong outside this model.
-final class Appearance {
+final class Appearance implements Mergeable<Appearance> {
   /// Creates an appearance from optional visual facets.
   const Appearance({this.surface, this.content, this.metrics});
 
@@ -46,26 +47,12 @@ final class Appearance {
   /// that facet is merged with the existing facet. Inside each facet, non-null
   /// properties from [later] replace earlier values and null properties leave
   /// earlier values unchanged.
+  @override
   Appearance merge(Appearance later) {
     return Appearance(
-      surface: switch ((surface, later.surface)) {
-        (final current?, final next?) => current.merge(next),
-        (final current?, null) => current,
-        (null, final next?) => next,
-        _ => null,
-      },
-      content: switch ((content, later.content)) {
-        (final current?, final next?) => current.merge(next),
-        (final current?, null) => current,
-        (null, final next?) => next,
-        _ => null,
-      },
-      metrics: switch ((metrics, later.metrics)) {
-        (final current?, final next?) => current.merge(next),
-        (final current?, null) => current,
-        (null, final next?) => next,
-        _ => null,
-      },
+      surface: surface.mergedWith(later.surface),
+      content: content.mergedWith(later.content),
+      metrics: metrics.mergedWith(later.metrics),
     );
   }
 }
@@ -75,7 +62,7 @@ final class Appearance {
 /// Surface properties describe the container plane: its fill, outline, radius,
 /// and elevation. They deliberately avoid CSS boxes, Flutter decorations, and
 /// Material components.
-final class Surface {
+final class Surface implements Mergeable<Surface> {
   /// Creates a partial surface declaration.
   const Surface({this.fill, this.stroke, this.radius, this.elevation});
 
@@ -92,6 +79,7 @@ final class Surface {
   final Property<Unit>? elevation;
 
   /// Returns this surface with non-null properties from [later] applied.
+  @override
   Surface merge(Surface later) {
     return Surface(
       fill: later.fill ?? fill,
@@ -107,7 +95,7 @@ final class Surface {
 /// Content properties describe visible children such as labels and icons. They
 /// do not describe the child widgets, DOM nodes, accessibility labels, or
 /// semantic actions that may eventually use these values.
-final class Content {
+final class Content implements Mergeable<Content> {
   /// Creates a partial content declaration.
   const Content({this.color, this.text, this.icon, this.opacity});
 
@@ -124,6 +112,7 @@ final class Content {
   final Property<double>? opacity;
 
   /// Returns this content with non-null properties from [later] applied.
+  @override
   Content merge(Content later) {
     return Content(
       color: later.color ?? color,
@@ -138,7 +127,7 @@ final class Content {
 ///
 /// Metrics describe the space a visual object asks for. They are not layout
 /// algorithms and do not decide flex, grid, constraints, or widget structure.
-final class Metrics {
+final class Metrics implements Mergeable<Metrics> {
   /// Creates a partial metrics declaration.
   const Metrics({
     this.padding,
@@ -177,14 +166,10 @@ final class Metrics {
 
   /// Returns this metrics declaration with non-null properties from [later]
   /// applied.
+  @override
   Metrics merge(Metrics later) {
     return Metrics(
-      padding: switch ((padding, later.padding)) {
-        (final current?, final next?) => current.merge(next),
-        (final current?, null) => current,
-        (null, final next?) => next,
-        _ => null,
-      },
+      padding: padding.mergedWith(later.padding),
       gap: later.gap ?? gap,
       width: later.width ?? width,
       height: later.height ?? height,
@@ -308,7 +293,7 @@ final class Unit {
 ///
 /// Each side is optional so padding can participate in appearance merging.
 /// Later insets override only the sides they set.
-final class Insets {
+final class Insets implements Mergeable<Insets> {
   /// Creates insets with explicit sides.
   const Insets.only({this.top, this.right, this.bottom, this.left});
 
@@ -339,6 +324,7 @@ final class Insets {
   final Property<Unit>? left;
 
   /// Returns this inset set with non-null sides from [later] applied.
+  @override
   Insets merge(Insets later) {
     return Insets.only(
       top: later.top ?? top,

--- a/lib/src/style/appearance.dart
+++ b/lib/src/style/appearance.dart
@@ -13,13 +13,13 @@ import 'identifier.dart';
 ///
 /// final control = Appearance(
 ///   surface: Surface(
-///     fill: AppearanceValue.term(actionFill),
-///     radius: AppearanceValue.term(controlRadius),
+///     fill: .term(actionFill),
+///     radius: .term(controlRadius),
 ///   ),
 ///   metrics: Metrics(
 ///     padding: Insets.symmetric(
-///       x: AppearanceValue.literal(Unit.px(16)),
-///       y: AppearanceValue.literal(Unit.px(8)),
+///       x: .literal(Unit.px(16)),
+///       y: .literal(Unit.px(8)),
 ///     ),
 ///   ),
 /// );
@@ -80,16 +80,16 @@ final class Surface {
   const Surface({this.fill, this.stroke, this.radius, this.elevation});
 
   /// The surface fill color.
-  final AppearanceValue<ColorValue>? fill;
+  final Property<ColorValue>? fill;
 
   /// The stroke or border color for the surface.
-  final AppearanceValue<ColorValue>? stroke;
+  final Property<ColorValue>? stroke;
 
   /// The corner radius or shape radius for the surface.
-  final AppearanceValue<Unit>? radius;
+  final Property<Unit>? radius;
 
   /// The platform-neutral elevation role or amount.
-  final AppearanceValue<Unit>? elevation;
+  final Property<Unit>? elevation;
 
   /// Returns this surface with non-null properties from [later] applied.
   Surface merge(Surface later) {
@@ -112,16 +112,16 @@ final class Content {
   const Content({this.color, this.text, this.icon, this.opacity});
 
   /// The foreground color for text or icons.
-  final AppearanceValue<ColorValue>? color;
+  final Property<ColorValue>? color;
 
   /// The semantic text role to use for labels.
-  final AppearanceValue<Identifier>? text;
+  final Property<Identifier>? text;
 
   /// The semantic icon role to use for icons.
-  final AppearanceValue<Identifier>? icon;
+  final Property<Identifier>? icon;
 
   /// The opacity applied to content.
-  final AppearanceValue<double>? opacity;
+  final Property<double>? opacity;
 
   /// Returns this content with non-null properties from [later] applied.
   Content merge(Content later) {
@@ -155,25 +155,25 @@ final class Metrics {
   final Insets? padding;
 
   /// Space between repeated children.
-  final AppearanceValue<Unit>? gap;
+  final Property<Unit>? gap;
 
   /// The preferred width.
-  final AppearanceValue<Unit>? width;
+  final Property<Unit>? width;
 
   /// The preferred height.
-  final AppearanceValue<Unit>? height;
+  final Property<Unit>? height;
 
   /// The minimum width.
-  final AppearanceValue<Unit>? minWidth;
+  final Property<Unit>? minWidth;
 
   /// The minimum height.
-  final AppearanceValue<Unit>? minHeight;
+  final Property<Unit>? minHeight;
 
   /// The maximum width.
-  final AppearanceValue<Unit>? maxWidth;
+  final Property<Unit>? maxWidth;
 
   /// The maximum height.
-  final AppearanceValue<Unit>? maxHeight;
+  final Property<Unit>? maxHeight;
 
   /// Returns this metrics declaration with non-null properties from [later]
   /// applied.
@@ -196,36 +196,58 @@ final class Metrics {
   }
 }
 
-/// A literal appearance value or a reference to a vocabulary term.
+/// A declared value for an appearance property.
 ///
-/// Appearance declarations can use concrete values directly, or defer the value
-/// to a [Binding] by referencing a [Term]. Resolution is intentionally not part
-/// of this type; a later resolver will choose a binding and replace term
-/// references with concrete values.
+/// A property is the assignable leaf in an [Appearance]. It either stores a
+/// concrete literal value, or it points at a vocabulary [Term] that will be
+/// resolved through a [Binding] later.
+///
+/// Use a literal when the declaration owns the exact value:
 ///
 /// ```dart
-/// const fill = AppearanceValue.literal(ColorValue.hex(0xff006adc));
-/// const fillTerm = Term<ColorValue>(Identifier('color.action.fill'));
-/// const referencedFill = AppearanceValue.term(fillTerm);
+/// const surface = Surface(fill: .literal(ColorValue.hex(0xff006adc)));
 /// ```
-final class AppearanceValue<T> {
-  /// Creates a concrete appearance value.
-  const AppearanceValue.literal(T value) : literal = value, term = null;
+///
+/// Use a term when the declaration should follow a shared binding:
+///
+/// ```dart
+/// const fillTerm = Term<ColorValue>(Identifier('color.action.fill'));
+///
+/// const surface = Surface(fill: .term(fillTerm));
+/// ```
+sealed class Property<T> {
+  /// Creates a property variant.
+  const Property();
 
-  /// Creates an appearance value that will be read from a binding later.
-  const AppearanceValue.term(Term<T> this.term) : literal = null;
+  /// Creates a property that stores a concrete [value].
+  const factory Property.literal(T value) = LiteralProperty<T>;
 
-  /// The concrete value, when this is a literal value.
-  final T? literal;
+  /// Creates a property that resolves through [term].
+  const factory Property.term(Term<T> term) = TermProperty<T>;
+}
 
-  /// The referenced term, when this value is binding-backed.
-  final Term<T>? term;
+/// A [Property] that stores a concrete value in the declaration itself.
+///
+/// Prefer this variant for values that are intentionally local to an
+/// appearance, such as one-off spacing or an override color.
+final class LiteralProperty<T> extends Property<T> {
+  /// Creates a property from a concrete [value].
+  const LiteralProperty(this.value);
 
-  /// Whether this value stores a literal value.
-  bool get isLiteral => term == null;
+  /// The concrete value carried by this property.
+  final T value;
+}
 
-  /// Whether this value references a [Term].
-  bool get isTerm => term != null;
+/// A [Property] that refers to a vocabulary term.
+///
+/// Prefer this variant when multiple appearances should share the same design
+/// decision through a [Binding], such as semantic color or radius terms.
+final class TermProperty<T> extends Property<T> {
+  /// Creates a property that resolves through [term].
+  const TermProperty(this.term);
+
+  /// The referenced term.
+  final Term<T> term;
 }
 
 /// A platform-neutral 32-bit ARGB color.
@@ -291,30 +313,30 @@ final class Insets {
   const Insets.only({this.top, this.right, this.bottom, this.left});
 
   /// Creates equal insets on every side.
-  const Insets.all(AppearanceValue<Unit> value)
+  const Insets.all(Property<Unit> value)
     : top = value,
       right = value,
       bottom = value,
       left = value;
 
   /// Creates horizontal and vertical insets.
-  const Insets.symmetric({AppearanceValue<Unit>? x, AppearanceValue<Unit>? y})
+  const Insets.symmetric({Property<Unit>? x, Property<Unit>? y})
     : top = y,
       right = x,
       bottom = y,
       left = x;
 
   /// The top inset.
-  final AppearanceValue<Unit>? top;
+  final Property<Unit>? top;
 
   /// The right inset.
-  final AppearanceValue<Unit>? right;
+  final Property<Unit>? right;
 
   /// The bottom inset.
-  final AppearanceValue<Unit>? bottom;
+  final Property<Unit>? bottom;
 
   /// The left inset.
-  final AppearanceValue<Unit>? left;
+  final Property<Unit>? left;
 
   /// Returns this inset set with non-null sides from [later] applied.
   Insets merge(Insets later) {

--- a/lib/src/style/binding.dart
+++ b/lib/src/style/binding.dart
@@ -8,22 +8,21 @@ import 'identifier.dart';
 /// [Binding]:
 ///
 /// ```dart
-/// const actionFill = Term<String>(Identifier('color.action.fill'));
+/// const actionFill = Term<Color>(Identifier('color.action.fill'));
 ///
 /// final light = Binding(Identifier('light'), [
-///   actionFill('#006adc'),
+///   actionFill(Color(0xff006adc)),
 /// ]);
 ///
 /// final dark = Binding(Identifier('dark'), [
-///   actionFill('#8ab4ff'),
+///   actionFill(Color(0xff8ab4ff)),
 /// ]);
 /// ```
 ///
 /// The type argument is part of the authoring contract. A
 /// `Term<double>` creates `Assignment<double>` values, while a `Term<String>`
-/// creates `Assignment<String>` values. The core does not prescribe concrete
-/// value classes in this slice so applications can start with ordinary Dart
-/// values and move to richer value objects later.
+/// creates `Assignment<String>` values. Use richer value types such as `Color`
+/// when the term should carry more structure than a primitive value.
 final class Term<T> {
   /// Creates a vocabulary term with a stable [id].
   const Term(this.id);
@@ -73,11 +72,11 @@ final class Assignment<T> {
 /// resolve terms, merge appearances, or choose a platform representation.
 ///
 /// ```dart
-/// const fill = Term<String>(Identifier('color.action.fill'));
+/// const fill = Term<Color>(Identifier('color.action.fill'));
 /// const radius = Term<double>(Identifier('radius.control'));
 ///
 /// final light = Binding(Identifier('light'), [
-///   fill('#006adc'),
+///   fill(Color(0xff006adc)),
 ///   radius(8),
 /// ]);
 /// ```

--- a/lib/src/style/color.dart
+++ b/lib/src/style/color.dart
@@ -1,0 +1,131 @@
+/// A platform-neutral color value.
+///
+/// The default constructor accepts the same `0xAARRGGBB` packed integer shape
+/// used by `dart:ui.Color`, without depending on Flutter's `dart:ui` library.
+/// Channels are stored as floating-point components so declarations can keep
+/// their authored values and convert back to an ARGB integer when needed.
+///
+/// ```dart
+/// const blue = Color(0xff42a5f5);
+/// const sameBlue = Color.fromARGB(0xff, 0x42, 0xa5, 0xf5);
+/// ```
+final class Color {
+  /// Creates an sRGB color from the lower 32 bits of [value].
+  ///
+  /// The bits are interpreted as `0xAARRGGBB`: alpha in bits 24-31, red in
+  /// bits 16-23, green in bits 8-15, and blue in bits 0-7.
+  const Color(int value)
+    : this._fromARGB(
+        (value >> 24) & 0xff,
+        (value >> 16) & 0xff,
+        (value >> 8) & 0xff,
+        value & 0xff,
+      );
+
+  /// Creates a color from floating-point channel values.
+  ///
+  /// The conventional range for each channel is `0.0` to `1.0`. Values outside
+  /// that range are preserved in the declaration and clamped only when
+  /// converted with [toARGB32].
+  const Color.from({
+    required double alpha,
+    required double red,
+    required double green,
+    required double blue,
+  }) : a = alpha,
+       r = red,
+       g = green,
+       b = blue;
+
+  /// Creates an sRGB color from integer alpha, red, green, and blue channels.
+  ///
+  /// Only the lower 8 bits of each channel are used, matching
+  /// `dart:ui.Color.fromARGB`.
+  const Color.fromARGB(int a, int r, int g, int b) : this._fromARGB(a, r, g, b);
+
+  /// Creates a color from red, green, blue, and opacity channels.
+  ///
+  /// Only the lower 8 bits of the red, green, and blue channels are used.
+  /// The conventional range for [opacity] is `0.0` to `1.0`.
+  const Color.fromRGBO(int r, int g, int b, double opacity)
+    : a = opacity,
+      r = (r & 0xff) / 255,
+      g = (g & 0xff) / 255,
+      b = (b & 0xff) / 255;
+
+  const Color._fromARGB(int alpha, int red, int green, int blue)
+    : this._fromRGBO(red, green, blue, (alpha & 0xff) / 255);
+
+  const Color._fromRGBO(int red, int green, int blue, double opacity)
+    : a = opacity,
+      r = (red & 0xff) / 255,
+      g = (green & 0xff) / 255,
+      b = (blue & 0xff) / 255;
+
+  /// The alpha channel as a floating-point component.
+  final double a;
+
+  /// The red channel as a floating-point component.
+  final double r;
+
+  /// The green channel as a floating-point component.
+  final double g;
+
+  /// The blue channel as a floating-point component.
+  final double b;
+
+  /// Returns a copy with the provided channels replaced.
+  Color withValues({double? alpha, double? red, double? green, double? blue}) {
+    return Color.from(
+      alpha: alpha ?? a,
+      red: red ?? r,
+      green: green ?? g,
+      blue: blue ?? b,
+    );
+  }
+
+  /// Returns this color as a packed `0xAARRGGBB` integer.
+  ///
+  /// Channel values are rounded to the nearest 8-bit integer and clamped to the
+  /// range `0..255`.
+  int toARGB32() {
+    return _floatToInt8(a) << 24 |
+        _floatToInt8(r) << 16 |
+        _floatToInt8(g) << 8 |
+        _floatToInt8(b);
+  }
+
+  static int _floatToInt8(double value) {
+    final scaled = (value * 255.0).round();
+
+    if (scaled < 0) {
+      return 0;
+    }
+    if (scaled > 255) {
+      return 255;
+    }
+    return scaled;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is Color &&
+        other.a == a &&
+        other.r == r &&
+        other.g == g &&
+        other.b == b;
+  }
+
+  @override
+  int get hashCode => Object.hash(a, r, g, b);
+
+  @override
+  String toString() {
+    return 'Color('
+        'alpha: ${a.toStringAsFixed(4)}, '
+        'red: ${r.toStringAsFixed(4)}, '
+        'green: ${g.toStringAsFixed(4)}, '
+        'blue: ${b.toStringAsFixed(4)}'
+        ')';
+  }
+}

--- a/lib/src/style/dimension.dart
+++ b/lib/src/style/dimension.dart
@@ -1,0 +1,54 @@
+/// A platform-neutral measurement used by visual style declarations.
+///
+/// Dimensions are Odroe's intermediate representation for lengths before a
+/// style is projected to CSS, Flutter, or another renderer. A dimension is not
+/// layout by itself: responsive selection, container queries, and platform
+/// fallback behavior belong to higher-level style resolution.
+///
+/// ```dart
+/// const fixed = Dimension.px(16);
+/// final shorthand = 16.px;
+/// ```
+sealed class Dimension {
+  /// Creates a dimension.
+  const Dimension();
+
+  /// Creates a logical pixel-like dimension.
+  ///
+  /// CSS adapters can project this as `px`; Flutter adapters can project this
+  /// as logical pixels. Other platforms should map it to their closest
+  /// device-independent length.
+  const factory Dimension.px(double value) = PixelDimension;
+}
+
+/// A logical pixel-like [Dimension].
+///
+/// This is the only dimension variant currently supported. Additional variants
+/// such as percentages or viewport-relative dimensions should be added as
+/// explicit subclasses with their own adapter semantics instead of as a unit
+/// enum.
+final class PixelDimension extends Dimension {
+  /// Creates a logical pixel-like dimension.
+  const PixelDimension(this.value);
+
+  /// The numeric amount.
+  final double value;
+
+  @override
+  bool operator ==(Object other) {
+    return other is PixelDimension && other.value == value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
+/// Converts numeric literals into dimensions.
+///
+/// Extension getters are not constant expressions. Use `Dimension.px(16)` when
+/// a `const` value is required, and `16.px` when authoring non-const
+/// declarations.
+extension DimensionNumberExtension on num {
+  /// Creates a logical pixel-like dimension from this number.
+  Dimension get px => Dimension.px(toDouble());
+}

--- a/lib/src/style/mergeable.dart
+++ b/lib/src/style/mergeable.dart
@@ -1,0 +1,24 @@
+/// A value that can merge another value of the same type into itself.
+///
+/// Implement this for partial declarations whose non-null members can be
+/// overlaid by a later declaration of the same shape.
+abstract interface class Mergeable<T> {
+  /// Returns the result of applying [later] over this value.
+  T merge(T later);
+}
+
+/// Merging support for optional declaration slots.
+extension MergeableNullable<T extends Mergeable<T>> on T? {
+  /// Returns the merged result of this value and [later].
+  ///
+  /// When both values are present, [later] is merged over this value. When only
+  /// one side is present, that side is returned unchanged.
+  T? mergedWith(T? later) {
+    return switch ((this, later)) {
+      (final current?, final next?) => current.merge(next),
+      (final current?, null) => current,
+      (null, final next?) => next,
+      _ => null,
+    };
+  }
+}

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -8,12 +8,12 @@
 /// bindings:
 ///
 /// ```dart
-/// const actionFill = Term<String>(Identifier('color.action.fill'));
-/// const actionContent = Term<String>(Identifier('color.action.content'));
+/// const actionFill = Term<Color>(Identifier('color.action.fill'));
+/// const actionContent = Term<Color>(Identifier('color.action.content'));
 ///
 /// final light = Binding(Identifier('light'), [
-///   actionFill('#006adc'),
-///   actionContent('#ffffff'),
+///   actionFill(Color(0xff006adc)),
+///   actionContent(Color(0xffffffff)),
 /// ]);
 /// ```
 ///

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -24,5 +24,7 @@ library;
 
 export 'src/style/appearance.dart';
 export 'src/style/binding.dart';
+export 'src/style/color.dart';
 export 'src/style/diagnostic.dart';
+export 'src/style/dimension.dart';
 export 'src/style/identifier.dart';

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -22,6 +22,7 @@
 /// values that other packages can adapt for Flutter, CSS, or other targets.
 library;
 
+export 'src/style/appearance.dart';
 export 'src/style/binding.dart';
 export 'src/style/diagnostic.dart';
 export 'src/style/identifier.dart';

--- a/test/style/appearance_test.dart
+++ b/test/style/appearance_test.dart
@@ -6,16 +6,13 @@ void main() {
     'declares visual fragments with concrete values and term references',
     () {
       const actionFill = Term<Color>(Identifier('color.action.fill'));
-      const controlRadius = Term<Unit>(Identifier('radius.control'));
+      const controlRadius = Term<Dimension>(Identifier('radius.control'));
 
       final appearance = Appearance(
         surface: Surface(fill: .term(actionFill), radius: .term(controlRadius)),
         content: const Content(color: .literal(Color(0xffffffff))),
-        metrics: const Metrics(
-          padding: Insets.symmetric(
-            x: .literal(Unit.px(16)),
-            y: .literal(Unit.px(8)),
-          ),
+        metrics: Metrics(
+          padding: Insets.symmetric(x: .literal(16.px), y: .literal(8.px)),
         ),
       );
 
@@ -29,7 +26,7 @@ void main() {
       );
       expect(
         appearance.surface?.radius,
-        isA<TermProperty<Unit>>().having(
+        isA<TermProperty<Dimension>>().having(
           (property) => property.term,
           'term',
           same(controlRadius),
@@ -45,10 +42,10 @@ void main() {
       );
       expect(
         appearance.metrics?.padding?.left,
-        isA<LiteralProperty<Unit>>().having(
+        isA<LiteralProperty<Dimension>>().having(
           (property) => property.value,
           'value',
-          const Unit.px(16),
+          const Dimension.px(16),
         ),
       );
     },
@@ -57,7 +54,7 @@ void main() {
   test('merges appearances by facet and property', () {
     const Property<Color> baseFill = .literal(Color(0xff006adc));
     const Property<Color> nextFill = .literal(Color(0xff004488));
-    const Property<Unit> radius = .literal(Unit.px(8));
+    const Property<Dimension> radius = .literal(Dimension.px(8));
     const Property<Color> contentColor = .literal(Color(0xffffffff));
 
     const base = Appearance(
@@ -76,45 +73,47 @@ void main() {
   test('merges metrics padding by side', () {
     const base = Metrics(
       padding: Insets.symmetric(
-        x: .literal(Unit.px(16)),
-        y: .literal(Unit.px(8)),
+        x: .literal(Dimension.px(16)),
+        y: .literal(Dimension.px(8)),
       ),
-      gap: .literal(Unit.px(4)),
+      gap: .literal(Dimension.px(4)),
     );
-    const later = Metrics(padding: Insets.only(left: .literal(Unit.px(20))));
+    const later = Metrics(
+      padding: Insets.only(left: .literal(Dimension.px(20))),
+    );
 
     final merged = base.merge(later);
 
     expect(
       merged.padding?.left,
-      isA<LiteralProperty<Unit>>().having(
+      isA<LiteralProperty<Dimension>>().having(
         (property) => property.value,
         'value',
-        const Unit.px(20),
+        const Dimension.px(20),
       ),
     );
     expect(
       merged.padding?.right,
-      isA<LiteralProperty<Unit>>().having(
+      isA<LiteralProperty<Dimension>>().having(
         (property) => property.value,
         'value',
-        const Unit.px(16),
+        const Dimension.px(16),
       ),
     );
     expect(
       merged.padding?.top,
-      isA<LiteralProperty<Unit>>().having(
+      isA<LiteralProperty<Dimension>>().having(
         (property) => property.value,
         'value',
-        const Unit.px(8),
+        const Dimension.px(8),
       ),
     );
     expect(
       merged.gap,
-      isA<LiteralProperty<Unit>>().having(
+      isA<LiteralProperty<Dimension>>().having(
         (property) => property.value,
         'value',
-        const Unit.px(4),
+        const Dimension.px(4),
       ),
     );
   });

--- a/test/style/appearance_test.dart
+++ b/test/style/appearance_test.dart
@@ -5,12 +5,12 @@ void main() {
   test(
     'declares visual fragments with concrete values and term references',
     () {
-      const actionFill = Term<ColorValue>(Identifier('color.action.fill'));
+      const actionFill = Term<Color>(Identifier('color.action.fill'));
       const controlRadius = Term<Unit>(Identifier('radius.control'));
 
       final appearance = Appearance(
         surface: Surface(fill: .term(actionFill), radius: .term(controlRadius)),
-        content: const Content(color: .literal(ColorValue.hex(0xffffffff))),
+        content: const Content(color: .literal(Color(0xffffffff))),
         metrics: const Metrics(
           padding: Insets.symmetric(
             x: .literal(Unit.px(16)),
@@ -21,7 +21,7 @@ void main() {
 
       expect(
         appearance.surface?.fill,
-        isA<TermProperty<ColorValue>>().having(
+        isA<TermProperty<Color>>().having(
           (property) => property.term,
           'term',
           same(actionFill),
@@ -37,10 +37,10 @@ void main() {
       );
       expect(
         appearance.content?.color,
-        isA<LiteralProperty<ColorValue>>().having(
+        isA<LiteralProperty<Color>>().having(
           (property) => property.value,
           'value',
-          const ColorValue.hex(0xffffffff),
+          const Color(0xffffffff),
         ),
       );
       expect(
@@ -55,12 +55,10 @@ void main() {
   );
 
   test('merges appearances by facet and property', () {
-    const Property<ColorValue> baseFill = .literal(ColorValue.hex(0xff006adc));
-    const Property<ColorValue> nextFill = .literal(ColorValue.hex(0xff004488));
+    const Property<Color> baseFill = .literal(Color(0xff006adc));
+    const Property<Color> nextFill = .literal(Color(0xff004488));
     const Property<Unit> radius = .literal(Unit.px(8));
-    const Property<ColorValue> contentColor = .literal(
-      ColorValue.hex(0xffffffff),
-    );
+    const Property<Color> contentColor = .literal(Color(0xffffffff));
 
     const base = Appearance(
       surface: Surface(fill: baseFill, radius: radius),

--- a/test/style/appearance_test.dart
+++ b/test/style/appearance_test.dart
@@ -9,36 +9,58 @@ void main() {
       const controlRadius = Term<Unit>(Identifier('radius.control'));
 
       final appearance = Appearance(
-        surface: Surface(
-          fill: AppearanceValue.term(actionFill),
-          radius: AppearanceValue.term(controlRadius),
-        ),
-        content: const Content(
-          color: AppearanceValue.literal(ColorValue.hex(0xffffffff)),
-        ),
+        surface: Surface(fill: .term(actionFill), radius: .term(controlRadius)),
+        content: const Content(color: .literal(ColorValue.hex(0xffffffff))),
         metrics: const Metrics(
           padding: Insets.symmetric(
-            x: AppearanceValue.literal(Unit.px(16)),
-            y: AppearanceValue.literal(Unit.px(8)),
+            x: .literal(Unit.px(16)),
+            y: .literal(Unit.px(8)),
           ),
         ),
       );
 
-      expect(appearance.surface?.fill?.term, same(actionFill));
-      expect(appearance.surface?.radius?.term, same(controlRadius));
       expect(
-        appearance.content?.color?.literal,
-        const ColorValue.hex(0xffffffff),
+        appearance.surface?.fill,
+        isA<TermProperty<ColorValue>>().having(
+          (property) => property.term,
+          'term',
+          same(actionFill),
+        ),
       );
-      expect(appearance.metrics?.padding?.left?.literal, const Unit.px(16));
+      expect(
+        appearance.surface?.radius,
+        isA<TermProperty<Unit>>().having(
+          (property) => property.term,
+          'term',
+          same(controlRadius),
+        ),
+      );
+      expect(
+        appearance.content?.color,
+        isA<LiteralProperty<ColorValue>>().having(
+          (property) => property.value,
+          'value',
+          const ColorValue.hex(0xffffffff),
+        ),
+      );
+      expect(
+        appearance.metrics?.padding?.left,
+        isA<LiteralProperty<Unit>>().having(
+          (property) => property.value,
+          'value',
+          const Unit.px(16),
+        ),
+      );
     },
   );
 
   test('merges appearances by facet and property', () {
-    const baseFill = AppearanceValue.literal(ColorValue.hex(0xff006adc));
-    const nextFill = AppearanceValue.literal(ColorValue.hex(0xff004488));
-    const radius = AppearanceValue.literal(Unit.px(8));
-    const contentColor = AppearanceValue.literal(ColorValue.hex(0xffffffff));
+    const Property<ColorValue> baseFill = .literal(ColorValue.hex(0xff006adc));
+    const Property<ColorValue> nextFill = .literal(ColorValue.hex(0xff004488));
+    const Property<Unit> radius = .literal(Unit.px(8));
+    const Property<ColorValue> contentColor = .literal(
+      ColorValue.hex(0xffffffff),
+    );
 
     const base = Appearance(
       surface: Surface(fill: baseFill, radius: radius),
@@ -56,20 +78,46 @@ void main() {
   test('merges metrics padding by side', () {
     const base = Metrics(
       padding: Insets.symmetric(
-        x: AppearanceValue.literal(Unit.px(16)),
-        y: AppearanceValue.literal(Unit.px(8)),
+        x: .literal(Unit.px(16)),
+        y: .literal(Unit.px(8)),
       ),
-      gap: AppearanceValue.literal(Unit.px(4)),
+      gap: .literal(Unit.px(4)),
     );
-    const later = Metrics(
-      padding: Insets.only(left: AppearanceValue.literal(Unit.px(20))),
-    );
+    const later = Metrics(padding: Insets.only(left: .literal(Unit.px(20))));
 
     final merged = base.merge(later);
 
-    expect(merged.padding?.left?.literal, const Unit.px(20));
-    expect(merged.padding?.right?.literal, const Unit.px(16));
-    expect(merged.padding?.top?.literal, const Unit.px(8));
-    expect(merged.gap?.literal, const Unit.px(4));
+    expect(
+      merged.padding?.left,
+      isA<LiteralProperty<Unit>>().having(
+        (property) => property.value,
+        'value',
+        const Unit.px(20),
+      ),
+    );
+    expect(
+      merged.padding?.right,
+      isA<LiteralProperty<Unit>>().having(
+        (property) => property.value,
+        'value',
+        const Unit.px(16),
+      ),
+    );
+    expect(
+      merged.padding?.top,
+      isA<LiteralProperty<Unit>>().having(
+        (property) => property.value,
+        'value',
+        const Unit.px(8),
+      ),
+    );
+    expect(
+      merged.gap,
+      isA<LiteralProperty<Unit>>().having(
+        (property) => property.value,
+        'value',
+        const Unit.px(4),
+      ),
+    );
   });
 }

--- a/test/style/appearance_test.dart
+++ b/test/style/appearance_test.dart
@@ -1,0 +1,75 @@
+import 'package:odroe/style.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'declares visual fragments with concrete values and term references',
+    () {
+      const actionFill = Term<ColorValue>(Identifier('color.action.fill'));
+      const controlRadius = Term<Unit>(Identifier('radius.control'));
+
+      final appearance = Appearance(
+        surface: Surface(
+          fill: AppearanceValue.term(actionFill),
+          radius: AppearanceValue.term(controlRadius),
+        ),
+        content: const Content(
+          color: AppearanceValue.literal(ColorValue.hex(0xffffffff)),
+        ),
+        metrics: const Metrics(
+          padding: Insets.symmetric(
+            x: AppearanceValue.literal(Unit.px(16)),
+            y: AppearanceValue.literal(Unit.px(8)),
+          ),
+        ),
+      );
+
+      expect(appearance.surface?.fill?.term, same(actionFill));
+      expect(appearance.surface?.radius?.term, same(controlRadius));
+      expect(
+        appearance.content?.color?.literal,
+        const ColorValue.hex(0xffffffff),
+      );
+      expect(appearance.metrics?.padding?.left?.literal, const Unit.px(16));
+    },
+  );
+
+  test('merges appearances by facet and property', () {
+    const baseFill = AppearanceValue.literal(ColorValue.hex(0xff006adc));
+    const nextFill = AppearanceValue.literal(ColorValue.hex(0xff004488));
+    const radius = AppearanceValue.literal(Unit.px(8));
+    const contentColor = AppearanceValue.literal(ColorValue.hex(0xffffffff));
+
+    const base = Appearance(
+      surface: Surface(fill: baseFill, radius: radius),
+      content: Content(color: contentColor),
+    );
+    const later = Appearance(surface: Surface(fill: nextFill));
+
+    final merged = base.merge(later);
+
+    expect(merged.surface?.fill, same(nextFill));
+    expect(merged.surface?.radius, same(radius));
+    expect(merged.content?.color, same(contentColor));
+  });
+
+  test('merges metrics padding by side', () {
+    const base = Metrics(
+      padding: Insets.symmetric(
+        x: AppearanceValue.literal(Unit.px(16)),
+        y: AppearanceValue.literal(Unit.px(8)),
+      ),
+      gap: AppearanceValue.literal(Unit.px(4)),
+    );
+    const later = Metrics(
+      padding: Insets.only(left: AppearanceValue.literal(Unit.px(20))),
+    );
+
+    final merged = base.merge(later);
+
+    expect(merged.padding?.left?.literal, const Unit.px(20));
+    expect(merged.padding?.right?.literal, const Unit.px(16));
+    expect(merged.padding?.top?.literal, const Unit.px(8));
+    expect(merged.gap?.literal, const Unit.px(4));
+  });
+}

--- a/test/style/color_test.dart
+++ b/test/style/color_test.dart
@@ -1,0 +1,42 @@
+import 'package:odroe/style.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('constructs colors from packed ARGB values', () {
+    const color = Color(0xff42a5f5);
+
+    expect(color.a, 1.0);
+    expect(color.r, closeTo(0x42 / 255, 0.0000001));
+    expect(color.g, closeTo(0xa5 / 255, 0.0000001));
+    expect(color.b, closeTo(0xf5 / 255, 0.0000001));
+    expect(color.toARGB32(), 0xff42a5f5);
+  });
+
+  test('uses the lower bits of integer constructors', () {
+    expect(const Color(0x1ff42a5f5), const Color(0xff42a5f5));
+    expect(
+      const Color.fromARGB(0x1ff, 0x142, 0x1a5, 0x1f5),
+      const Color(0xff42a5f5),
+    );
+  });
+
+  test('constructs colors from ARGB and RGBO channels', () {
+    expect(
+      const Color.fromARGB(0xff, 0x42, 0xa5, 0xf5),
+      const Color(0xff42a5f5),
+    );
+    expect(const Color.fromRGBO(0x42, 0xa5, 0xf5, 1), const Color(0xff42a5f5));
+  });
+
+  test('updates individual channels', () {
+    final color = const Color(0xff42a5f5).withValues(alpha: 0.5, red: 1);
+
+    expect(color.toARGB32(), 0x80ffa5f5);
+  });
+
+  test('clamps floating-point channels when converting to ARGB', () {
+    const color = Color.from(alpha: 2, red: -1, green: 0.5, blue: 1.5);
+
+    expect(color.toARGB32(), 0xff0080ff);
+  });
+}

--- a/test/style/dimension_test.dart
+++ b/test/style/dimension_test.dart
@@ -1,0 +1,17 @@
+import 'package:odroe/style.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('creates pixel dimensions from const constructors', () {
+    const dimension = Dimension.px(16);
+
+    expect(dimension, isA<PixelDimension>());
+    expect((dimension as PixelDimension).value, 16);
+  });
+
+  test('creates pixel dimensions from numeric shorthand', () {
+    final dimension = 16.px;
+
+    expect(dimension, const Dimension.px(16));
+  });
+}


### PR DESCRIPTION
## Summary

- Add the platform-neutral `Appearance` model with `Surface`, `Content`, `Metrics`, and `Insets` facets.
- Add merge semantics for appearance fragments and shared merge helpers for optional facets.
- Add typed appearance properties that can be literals or term references.
- Add style value primitives for colors and dimensions, including `Color`, `Dimension.px(...)`, and `num.px` shorthand.

## Validation

- `dart analyze .`
- `dart test`
- `dart doc --dry-run .`
- `git diff --check`
- Flutter compatibility probe for `Color.toARGB32()` against `dart:ui.Color`

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a platform-neutral styling system with support for appearance, color, dimension, spacing, and sizing values.
  * Introduced flexible value types for colors and lengths, including shorthand helpers for common style values.

* **Bug Fixes**
  * Improved merging behavior so later style values override only the fields they specify, preserving existing settings.
  * Updated examples to use strongly typed style values for clearer, more consistent usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->