### PR TITLE
feat: add style conditions and cases

### DIFF
--- a/lib/src/style/axis.dart
+++ b/lib/src/style/axis.dart
@@ -1,0 +1,48 @@
+import 'condition.dart';
+import 'identifier.dart';
+
+/// A typed style axis that can produce conditions for one axis value.
+///
+/// Axes model authored variants such as tone, size, density, or emphasis. An
+/// axis is not a resolved value; it describes one input dimension that a later
+/// style resolver can match against.
+///
+/// Calling an axis creates an [AxisCondition]:
+///
+/// ```dart
+/// enum ButtonTone { primary, danger }
+///
+/// const tone = Axis<ButtonTone>(
+///   id: Identifier('button.tone'),
+///   defaultValue: ButtonTone.primary,
+/// );
+///
+/// final danger = tone(.danger);
+/// ```
+final class Axis<T> {
+  /// Creates a style axis with a stable [id] and [defaultValue].
+  const Axis({required this.id, required this.defaultValue});
+
+  /// The authoring name used for validation, diagnostics, and future tooling.
+  final Identifier id;
+
+  /// The value used when no condition provides a value for this axis.
+  final T defaultValue;
+
+  /// Creates a condition that matches this axis at [value].
+  AxisCondition<T> call(T value) {
+    return AxisCondition<T>(this, value);
+  }
+}
+
+/// A condition produced by an [Axis] and one typed axis value.
+final class AxisCondition<T> extends Condition {
+  /// Creates a condition that matches [axis] at [value].
+  const AxisCondition(this.axis, this.value);
+
+  /// The axis being matched.
+  final Axis<T> axis;
+
+  /// The axis value being matched.
+  final T value;
+}

--- a/lib/src/style/case.dart
+++ b/lib/src/style/case.dart
@@ -1,0 +1,40 @@
+import 'appearance.dart';
+import 'condition.dart';
+
+/// A conditional appearance override.
+///
+/// A case pairs one [Condition] with the [Appearance] that should apply when
+/// the condition matches. Cases deliberately replace separate variant, state,
+/// rule, and compound-variant APIs with one data model.
+///
+/// Dart dot shorthand keeps case authoring compact in `List<Case>` contexts:
+///
+/// ```dart
+/// final cases = <Case>[
+///   .when(state.hovered, Appearance()),
+///   .all([state.focused, state.error], Appearance()),
+/// ];
+/// ```
+final class Case {
+  /// Creates a case for [when] and [appearance].
+  const Case(this.when, this.appearance);
+
+  /// Creates a case that applies when [condition] matches.
+  const factory Case.when(Condition condition, Appearance appearance) = Case;
+
+  /// Creates a case that applies when every [condition] matches.
+  factory Case.all(Iterable<Condition> conditions, Appearance appearance) {
+    return Case(Condition.all(conditions), appearance);
+  }
+
+  /// Creates a case that applies when any [condition] matches.
+  factory Case.any(Iterable<Condition> conditions, Appearance appearance) {
+    return Case(Condition.any(conditions), appearance);
+  }
+
+  /// The condition that controls whether [appearance] applies.
+  final Condition when;
+
+  /// The appearance applied when [when] matches.
+  final Appearance appearance;
+}

--- a/lib/src/style/condition.dart
+++ b/lib/src/style/condition.dart
@@ -1,0 +1,51 @@
+/// A condition that controls whether a case applies.
+///
+/// Conditions are the single conditional styling model in Odroe. Axis values,
+/// states, and compound logic all flow through this type instead of separate
+/// `variants`, `states`, `rules`, or `compoundVariants` APIs.
+abstract base class Condition {
+  /// Creates a condition.
+  const Condition();
+
+  /// Creates a condition that matches when every [condition] matches.
+  factory Condition.all(Iterable<Condition> conditions) {
+    return AllCondition(conditions);
+  }
+
+  /// Creates a condition that matches when any [condition] matches.
+  factory Condition.any(Iterable<Condition> conditions) {
+    return AnyCondition(conditions);
+  }
+
+  /// Creates a condition that matches when [condition] does not match.
+  const factory Condition.not(Condition condition) = NotCondition;
+}
+
+/// A condition that requires every child condition to match.
+final class AllCondition extends Condition {
+  /// Creates a compound condition from [conditions].
+  AllCondition(Iterable<Condition> conditions)
+    : conditions = List.unmodifiable(conditions);
+
+  /// The conditions that must all match.
+  final List<Condition> conditions;
+}
+
+/// A condition that requires at least one child condition to match.
+final class AnyCondition extends Condition {
+  /// Creates a compound condition from [conditions].
+  AnyCondition(Iterable<Condition> conditions)
+    : conditions = List.unmodifiable(conditions);
+
+  /// The conditions where any one match is sufficient.
+  final List<Condition> conditions;
+}
+
+/// A condition that negates another condition.
+final class NotCondition extends Condition {
+  /// Creates a negated condition.
+  const NotCondition(this.condition);
+
+  /// The condition whose match result is negated.
+  final Condition condition;
+}

--- a/lib/src/style/state.dart
+++ b/lib/src/style/state.dart
@@ -1,0 +1,62 @@
+import 'condition.dart';
+import 'identifier.dart';
+
+/// A semantic visual state exposed to style declarations.
+///
+/// States describe platform-neutral interaction or data states such as hover,
+/// pressed, disabled, selected, or error. Platform pseudo selectors and widget
+/// lifecycle details are adapter concerns, not core states.
+final class State extends Condition {
+  /// Creates a state with a stable [id].
+  const State(this.id);
+
+  /// The authoring name for this state.
+  final Identifier id;
+}
+
+/// The built-in style state namespace.
+///
+/// Use this value as the public entry point for core semantic states:
+///
+/// ```dart
+/// final hoveredCase = Case.when(state.hovered, Appearance());
+/// ```
+const state = States._();
+
+/// Built-in platform-neutral visual states.
+///
+/// The namespace keeps common states discoverable without exporting global
+/// constants for each individual state.
+final class States {
+  const States._();
+
+  /// Pointer hover state.
+  State get hovered => const State(Identifier('state.hovered'));
+
+  /// Active press state.
+  State get pressed => const State(Identifier('state.pressed'));
+
+  /// Input focus state.
+  State get focused => const State(Identifier('state.focused'));
+
+  /// Focus state that should display a visible focus affordance.
+  State get focusVisible => const State(Identifier('state.focusVisible'));
+
+  /// Disabled state.
+  State get disabled => const State(Identifier('state.disabled'));
+
+  /// Selected state.
+  State get selected => const State(Identifier('state.selected'));
+
+  /// Checked state.
+  State get checked => const State(Identifier('state.checked'));
+
+  /// Expanded state.
+  State get expanded => const State(Identifier('state.expanded'));
+
+  /// Loading or pending state.
+  State get loading => const State(Identifier('state.loading'));
+
+  /// Error state.
+  State get error => const State(Identifier('state.error'));
+}

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -23,8 +23,12 @@
 library;
 
 export 'src/style/appearance.dart';
+export 'src/style/axis.dart';
 export 'src/style/binding.dart';
+export 'src/style/case.dart';
 export 'src/style/color.dart';
+export 'src/style/condition.dart';
 export 'src/style/diagnostic.dart';
 export 'src/style/dimension.dart';
 export 'src/style/identifier.dart';
+export 'src/style/state.dart';

--- a/test/style/condition_test.dart
+++ b/test/style/condition_test.dart
@@ -1,0 +1,105 @@
+import 'package:odroe/style.dart';
+import 'package:test/test.dart';
+
+enum ButtonSize { sm, md }
+
+enum ButtonTone { primary, danger }
+
+void main() {
+  test('creates typed axis conditions by calling an axis', () {
+    const tone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+
+    final condition = tone(.danger);
+
+    expect(condition.axis, same(tone));
+    expect(condition.value, ButtonTone.danger);
+  });
+
+  test('exposes the core semantic state namespace', () {
+    expect(state.hovered.id.value, 'state.hovered');
+    expect(state.pressed.id.value, 'state.pressed');
+    expect(state.focused.id.value, 'state.focused');
+    expect(state.focusVisible.id.value, 'state.focusVisible');
+    expect(state.disabled.id.value, 'state.disabled');
+    expect(state.selected.id.value, 'state.selected');
+    expect(state.checked.id.value, 'state.checked');
+    expect(state.expanded.id.value, 'state.expanded');
+    expect(state.loading.id.value, 'state.loading');
+    expect(state.error.id.value, 'state.error');
+  });
+
+  test('creates cases with dot shorthand factories', () {
+    const tone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    const size = Axis<ButtonSize>(
+      id: Identifier('button.size'),
+      defaultValue: ButtonSize.md,
+    );
+
+    final danger = tone(.danger);
+    final cases = <Case>[
+      .when(danger, const Appearance()),
+      .when(state.hovered, const Appearance()),
+      .all([tone(.danger), size(.sm)], const Appearance()),
+      .any([state.pressed, state.focusVisible], const Appearance()),
+    ];
+
+    expect(cases[0].when, same(danger));
+    expect(cases[1].when, same(state.hovered));
+    expect(
+      cases[2].when,
+      isA<AllCondition>()
+          .having((condition) => condition.conditions, 'conditions', [
+            isA<AxisCondition<ButtonTone>>()
+                .having((condition) => condition.axis, 'axis', same(tone))
+                .having(
+                  (condition) => condition.value,
+                  'value',
+                  ButtonTone.danger,
+                ),
+            isA<AxisCondition<ButtonSize>>()
+                .having((condition) => condition.axis, 'axis', same(size))
+                .having((condition) => condition.value, 'value', ButtonSize.sm),
+          ]),
+    );
+    expect(
+      cases[3].when,
+      isA<AnyCondition>().having(
+        (condition) => condition.conditions,
+        'conditions',
+        [same(state.pressed), same(state.focusVisible)],
+      ),
+    );
+  });
+
+  test('copies compound condition inputs into immutable lists', () {
+    final conditions = [state.hovered];
+
+    final condition = Condition.all(conditions) as AllCondition;
+    conditions.add(state.focusVisible);
+
+    expect(condition.conditions, hasLength(1));
+    expect(
+      () => condition.conditions.add(state.disabled),
+      throwsUnsupportedError,
+    );
+  });
+
+  test('creates negated conditions', () {
+    const condition = Condition.not(State(Identifier('state.disabled')));
+
+    expect(
+      condition,
+      isA<NotCondition>().having(
+        (condition) => (condition.condition as State).id.value,
+        'state id',
+        'state.disabled',
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Add typed style axes and callable axis conditions.
- Add the core condition model with all/any/not compound conditions.
- Add semantic state primitives and the built-in `state` namespace.
- Add `Case` factories for dot-shorthand authoring in `List<Case>` contexts.

## Validation

- `dart analyze .`
- `dart test`
- `dart doc --dry-run .`
- `git diff --check`

Closes #43