### PR TITLE
feat: add design validation manifest

### DIFF
--- a/lib/src/style/axis.dart
+++ b/lib/src/style/axis.dart
@@ -1,5 +1,6 @@
 import 'condition.dart';
 import 'identifier.dart';
+import 'value_contract.dart';
 
 /// A typed style axis that can produce conditions for one axis value.
 ///
@@ -19,15 +20,44 @@ import 'identifier.dart';
 ///
 /// final danger = tone(.danger);
 /// ```
-final class Axis<T> {
+final class Axis<T> implements ValueContract<T> {
   /// Creates a style axis with a stable [id] and [defaultValue].
   const Axis({required this.id, required this.defaultValue});
 
   /// The authoring name used for validation, diagnostics, and future tooling.
+  @override
   final Identifier id;
 
   /// The value used when no condition provides a value for this axis.
   final T defaultValue;
+
+  /// The runtime type represented by this axis.
+  ///
+  /// Validators use this after declarations have been widened to
+  /// `Axis<Object?>` and need to compare a condition axis against a contract
+  /// axis.
+  @override
+  Type get valueType => T;
+
+  /// Whether [value] can be used as a value for this axis.
+  ///
+  /// This mirrors the static contract enforced by [call]. It lets design-level
+  /// validation reject conditions built from a different axis object that reuses
+  /// the same identifier with an incompatible type argument.
+  @override
+  bool acceptsValue(Object? value) {
+    return value is T;
+  }
+
+  /// Whether [contract] names this same typed style axis.
+  ///
+  /// Two value contracts are compatible only when both the identifier and value
+  /// type match. This lets validators distinguish an undeclared axis from an
+  /// axis that reuses the same identifier with a different type argument.
+  @override
+  bool acceptsContract(ValueContract<Object?> contract) {
+    return contract.id == id && contract.valueType == valueType;
+  }
 
   /// Creates a condition that matches this axis at [value].
   AxisCondition<T> call(T value) {

--- a/lib/src/style/binding.dart
+++ b/lib/src/style/binding.dart
@@ -31,6 +31,22 @@ final class Term<T> {
   /// resolution.
   final Identifier id;
 
+  /// The runtime type represented by this term.
+  ///
+  /// Validators use this when a declaration has been widened to `Term` or
+  /// `Assignment<Object?>` and needs to compare authored values against the
+  /// typed vocabulary term.
+  Type get valueType => T;
+
+  /// Whether [value] can be assigned to this term.
+  ///
+  /// This mirrors the static contract enforced by [call]. It lets design-level
+  /// validation catch values that were introduced through a different `Term`
+  /// with the same identifier but an incompatible type argument.
+  bool accepts(Object? value) {
+    return value is T;
+  }
+
   /// Creates an [Assignment] that gives this term a concrete value.
   ///
   /// Calling a term is only declaration syntax. It does not validate [value],

--- a/lib/src/style/binding.dart
+++ b/lib/src/style/binding.dart
@@ -1,5 +1,6 @@
 import 'diagnostic.dart';
 import 'identifier.dart';
+import 'value_contract.dart';
 
 /// A typed word in a design vocabulary.
 ///
@@ -23,12 +24,13 @@ import 'identifier.dart';
 /// `Term<double>` creates `Assignment<double>` values, while a `Term<String>`
 /// creates `Assignment<String>` values. Use richer value types such as `Color`
 /// when the term should carry more structure than a primitive value.
-final class Term<T> {
+final class Term<T> implements ValueContract<T> {
   /// Creates a vocabulary term with a stable [id].
   const Term(this.id);
 
   /// The authoring name used to match assignments, diagnostics, and future
   /// resolution.
+  @override
   final Identifier id;
 
   /// The runtime type represented by this term.
@@ -36,6 +38,7 @@ final class Term<T> {
   /// Validators use this when a declaration has been widened to `Term` or
   /// `Assignment<Object?>` and needs to compare authored values against the
   /// typed vocabulary term.
+  @override
   Type get valueType => T;
 
   /// Whether [value] can be assigned to this term.
@@ -43,8 +46,19 @@ final class Term<T> {
   /// This mirrors the static contract enforced by [call]. It lets design-level
   /// validation catch values that were introduced through a different `Term`
   /// with the same identifier but an incompatible type argument.
-  bool accepts(Object? value) {
+  @override
+  bool acceptsValue(Object? value) {
     return value is T;
+  }
+
+  /// Whether [contract] names this same typed vocabulary slot.
+  ///
+  /// Two value contracts are compatible only when both the identifier and value
+  /// type match. This lets validators distinguish a missing term from a term
+  /// that reuses the same identifier with a different type argument.
+  @override
+  bool acceptsContract(ValueContract<Object?> contract) {
+    return contract.id == id && contract.valueType == valueType;
   }
 
   /// Creates an [Assignment] that gives this term a concrete value.

--- a/lib/src/style/contract.dart
+++ b/lib/src/style/contract.dart
@@ -1,4 +1,5 @@
 import 'axis.dart';
+import 'identifier.dart';
 import 'state.dart';
 
 /// The optional styleable shape for a [Style].
@@ -51,9 +52,23 @@ final class Contract<P> {
     return parts.contains(part);
   }
 
+  /// Returns the declared axis with [id], if this contract exposes one.
+  ///
+  /// This lookup intentionally matches by identifier only. Call [allowsAxis] or
+  /// the returned axis's value contract when type compatibility matters.
+  Axis<Object?>? axisNamed(Identifier id) {
+    for (final axis in axes) {
+      if (axis.id == id) {
+        return axis;
+      }
+    }
+
+    return null;
+  }
+
   /// Whether [axis] is declared by this contract.
   bool allowsAxis(Axis<Object?> axis) {
-    return axes.any((declared) => declared.id == axis.id);
+    return axisNamed(axis.id)?.acceptsContract(axis) ?? false;
   }
 
   /// Whether [state] is declared by this contract.

--- a/lib/src/style/design.dart
+++ b/lib/src/style/design.dart
@@ -91,6 +91,7 @@ final class Design<V extends Vocabulary> {
   /// * duplicate assignments inside each binding;
   /// * vocabulary terms missing from a binding;
   /// * binding assignments that do not belong to the vocabulary;
+  /// * binding assignments whose values do not match the vocabulary term type;
   /// * style appearance term references that do not belong to the vocabulary;
   /// * style parts, axes, and states that are not declared by the style contract.
   ///
@@ -104,7 +105,8 @@ final class Design<V extends Vocabulary> {
   /// }
   /// ```
   List<Diagnostic> validate() {
-    final vocabularyIds = {for (final term in terms) term.id.value};
+    final vocabularyById = _termsById(terms);
+    final vocabularyIds = vocabularyById.keys.toSet();
     final diagnostics = <Diagnostic>[
       ..._validateIdentifiers(kind: 'term', ids: terms.map((term) => term.id)),
       ..._validateIdentifiers(kind: 'binding', ids: bindings.map((b) => b.id)),
@@ -113,7 +115,7 @@ final class Design<V extends Vocabulary> {
 
     for (final binding in bindings) {
       diagnostics.addAll(binding.validate());
-      diagnostics.addAll(_validateBindingVocabulary(binding, vocabularyIds));
+      diagnostics.addAll(_validateBindingVocabulary(binding, vocabularyById));
     }
 
     for (final style in styles) {
@@ -130,28 +132,45 @@ final class Design<V extends Vocabulary> {
 
   List<Diagnostic> _validateBindingVocabulary(
     Binding binding,
-    Set<String> vocabularyIds,
+    Map<String, Term> vocabularyById,
   ) {
     final diagnostics = <Diagnostic>[];
-    final assigned = {
-      for (final assignment in binding.assignments) assignment.term.id.value,
-    };
+    final assigned = <String>{};
 
     for (final assignment in binding.assignments) {
       final termId = assignment.term.id.value;
-      if (vocabularyIds.contains(termId)) {
+      final vocabularyTerm = vocabularyById[termId];
+      if (vocabularyTerm == null) {
+        diagnostics.add(
+          Diagnostic(
+            code: DiagnosticCodes.designUnknownBindingValue,
+            target: DiagnosticTarget(kind: 'assignment', name: termId),
+            message:
+                'Binding `${binding.id.value}` assigns term `$termId`, but '
+                'this term is not declared by the design vocabulary.',
+          ),
+        );
+
         continue;
       }
 
-      diagnostics.add(
-        Diagnostic(
-          code: DiagnosticCodes.designUnknownBindingValue,
-          target: DiagnosticTarget(kind: 'assignment', name: termId),
-          message:
-              'Binding `${binding.id.value}` assigns term `$termId`, but this '
-              'term is not declared by the design vocabulary.',
-        ),
-      );
+      if (!vocabularyTerm.accepts(assignment.value)) {
+        diagnostics.add(
+          Diagnostic(
+            code: DiagnosticCodes.designInvalidBindingValueType,
+            target: DiagnosticTarget(kind: 'assignment', name: termId),
+            message:
+                'Binding `${binding.id.value}` assigns a '
+                '${assignment.value.runtimeType} value to term `$termId`, but '
+                'the design vocabulary declares that term as '
+                '${vocabularyTerm.valueType}.',
+          ),
+        );
+
+        continue;
+      }
+
+      assigned.add(termId);
     }
 
     for (final term in terms) {
@@ -307,6 +326,16 @@ final class Design<V extends Vocabulary> {
         return const [];
     }
   }
+}
+
+Map<String, Term> _termsById(Iterable<Term> terms) {
+  final termsById = <String, Term>{};
+
+  for (final term in terms) {
+    termsById.putIfAbsent(term.id.value, () => term);
+  }
+
+  return termsById;
 }
 
 Iterable<Term> _appearanceTerms(Appearance appearance) sync* {

--- a/lib/src/style/design.dart
+++ b/lib/src/style/design.dart
@@ -10,7 +10,7 @@ import 'style.dart';
 /// A platform-neutral manifest for one style system.
 ///
 /// A design gathers the declarations that need to agree with each other: the
-/// typed terms object a system authors against, the bindings that give those
+/// typed vocabulary object a system authors against, the bindings that give its
 /// terms values, the styles that consume appearances and contracts, and the
 /// custom policies a project wants to enforce.
 ///
@@ -18,7 +18,7 @@ import 'style.dart';
 /// const t = AppTerms();
 ///
 /// final design = Design(
-///   terms: t,
+///   vocabulary: t,
 ///   bindings: [
 ///     Binding(Identifier('light'), [
 ///       t.color.action.fill(const Color(0xff006adc)),
@@ -40,34 +40,33 @@ import 'style.dart';
 /// Validation stays in the core model. It reports missing declarations and
 /// policy findings, but it does not project the design to CSS, Flutter, Material,
 /// Jaspr, or any other platform.
-final class Design {
+final class Design<V extends Vocabulary> {
   /// Creates a style design manifest.
   ///
   /// All collections are copied into immutable lists. Mutating a source list
   /// after construction will not change the design being validated.
   Design({
-    required Vocabulary terms,
+    required this.vocabulary,
     Iterable<Binding> bindings = const [],
     Iterable<Style> styles = const [],
     Iterable<Policy> policies = const [],
-  }) : terms = terms,
-       vocabulary = List.unmodifiable(terms.terms),
+  }) : terms = List.unmodifiable(vocabulary.terms),
        bindings = List.unmodifiable(bindings),
        styles = List.unmodifiable(styles),
        policies = List.unmodifiable(policies);
 
-  /// The typed terms object used when authoring bindings and appearances.
+  /// The typed vocabulary object used when authoring bindings and appearances.
   ///
   /// This is the same `t` object a package can expose to authors. It may be
   /// written by hand or generated later, but it remains a normal Dart object.
-  final Vocabulary terms;
+  final V vocabulary;
 
   /// The flattened terms that bindings are expected to assign.
   ///
-  /// [Design] derives this list from [terms] at construction time. It exists so
-  /// validators and policies can inspect the complete vocabulary without knowing
-  /// the shape of a project's typed term tree.
-  final List<Term> vocabulary;
+  /// [Design] derives this list from [vocabulary] at construction time. It
+  /// exists so validators and policies can inspect the complete vocabulary
+  /// without knowing the shape of a project's typed term tree.
+  final List<Term> terms;
 
   /// The named value sets available to resolve vocabulary terms.
   final List<Binding> bindings;
@@ -103,10 +102,7 @@ final class Design {
   /// ```
   List<Diagnostic> validate() {
     final diagnostics = <Diagnostic>[
-      ..._validateIdentifiers(
-        kind: 'term',
-        ids: vocabulary.map((term) => term.id),
-      ),
+      ..._validateIdentifiers(kind: 'term', ids: terms.map((term) => term.id)),
       ..._validateIdentifiers(kind: 'binding', ids: bindings.map((b) => b.id)),
       ..._validateIdentifiers(kind: 'style', ids: styles.map((s) => s.id)),
     ];
@@ -134,7 +130,7 @@ final class Design {
       for (final assignment in binding.assignments) assignment.term.id.value,
     };
 
-    for (final term in vocabulary) {
+    for (final term in terms) {
       if (assigned.contains(term.id.value)) {
         continue;
       }
@@ -277,11 +273,11 @@ abstract interface class Policy {
   void evaluate(PolicyContext context);
 }
 
-/// A typed term tree that can expose all of its vocabulary terms.
+/// A typed vocabulary tree that can expose its terms.
 ///
-/// The public design API accepts `terms: t` so authoring code can keep using a
-/// domain-specific object such as `t.color.action.fill`. This protocol is the
-/// bridge that lets validation also enumerate those terms:
+/// The public design API accepts `vocabulary: t` so authoring code can keep
+/// using a domain-specific object such as `t.color.action.fill`. This protocol is
+/// the bridge that lets validation also enumerate those terms:
 ///
 /// ```dart
 /// final class AppTerms implements Vocabulary {

--- a/lib/src/style/design.dart
+++ b/lib/src/style/design.dart
@@ -48,7 +48,7 @@ final class Design {
   Design({
     required Vocabulary terms,
     Iterable<Binding> bindings = const [],
-    Iterable<Style<Object?>> styles = const [],
+    Iterable<Style> styles = const [],
     Iterable<Policy> policies = const [],
   }) : terms = terms,
        vocabulary = List.unmodifiable(terms.terms),
@@ -67,13 +67,13 @@ final class Design {
   /// [Design] derives this list from [terms] at construction time. It exists so
   /// validators and policies can inspect the complete vocabulary without knowing
   /// the shape of a project's typed term tree.
-  final List<Term<Object?>> vocabulary;
+  final List<Term> vocabulary;
 
   /// The named value sets available to resolve vocabulary terms.
   final List<Binding> bindings;
 
   /// The reusable style declarations in this design.
-  final List<Style<Object?>> styles;
+  final List<Style> styles;
 
   /// Custom project rules that run after structural validation.
   ///
@@ -153,7 +153,7 @@ final class Design {
     return diagnostics;
   }
 
-  List<Diagnostic> _validateStyle(Style<Object?> style) {
+  List<Diagnostic> _validateStyle(Style style) {
     final contract = style.contract;
     final diagnostics = <Diagnostic>[];
 
@@ -196,8 +196,8 @@ final class Design {
   }
 
   List<Diagnostic> _validateCondition(
-    Style<Object?> style,
-    Contract<Object?>? contract,
+    Style style,
+    Contract? contract,
     Condition condition,
   ) {
     switch (condition) {
@@ -291,7 +291,7 @@ abstract interface class Policy {
 ///   RadiusTerms get radius => const RadiusTerms();
 ///
 ///   @override
-///   Iterable<Term<Object?>> get terms => [
+///   Iterable<Term> get terms => [
 ///     color.action.fill,
 ///     radius.control,
 ///   ];
@@ -302,7 +302,7 @@ abstract interface class Policy {
 /// to introduce a second style language or hidden runtime registry.
 abstract interface class Vocabulary {
   /// Every term that belongs to this vocabulary.
-  Iterable<Term<Object?>> get terms;
+  Iterable<Term> get terms;
 }
 
 /// The reporting surface passed to [Policy.evaluate].

--- a/lib/src/style/design.dart
+++ b/lib/src/style/design.dart
@@ -89,6 +89,7 @@ final class Design<V extends Vocabulary> {
   /// * duplicate term, binding, and style identifiers;
   /// * duplicate assignments inside each binding;
   /// * vocabulary terms missing from a binding;
+  /// * binding assignments that do not belong to the vocabulary;
   /// * style parts, axes, and states that are not declared by the style contract.
   ///
   /// Each [Policy] then receives a [PolicyContext] for project-specific checks:
@@ -109,7 +110,7 @@ final class Design<V extends Vocabulary> {
 
     for (final binding in bindings) {
       diagnostics.addAll(binding.validate());
-      diagnostics.addAll(_validateBindingCompleteness(binding));
+      diagnostics.addAll(_validateBindingVocabulary(binding));
     }
 
     for (final style in styles) {
@@ -124,11 +125,29 @@ final class Design<V extends Vocabulary> {
     return diagnostics;
   }
 
-  List<Diagnostic> _validateBindingCompleteness(Binding binding) {
+  List<Diagnostic> _validateBindingVocabulary(Binding binding) {
     final diagnostics = <Diagnostic>[];
+    final vocabularyIds = {for (final term in terms) term.id.value};
     final assigned = {
       for (final assignment in binding.assignments) assignment.term.id.value,
     };
+
+    for (final assignment in binding.assignments) {
+      final termId = assignment.term.id.value;
+      if (vocabularyIds.contains(termId)) {
+        continue;
+      }
+
+      diagnostics.add(
+        Diagnostic(
+          code: DiagnosticCodes.designUnknownBindingValue,
+          target: DiagnosticTarget(kind: 'assignment', name: termId),
+          message:
+              'Binding `${binding.id.value}` assigns term `$termId`, but this '
+              'term is not declared by the design vocabulary.',
+        ),
+      );
+    }
 
     for (final term in terms) {
       if (assigned.contains(term.id.value)) {

--- a/lib/src/style/design.dart
+++ b/lib/src/style/design.dart
@@ -1,4 +1,5 @@
 import 'axis.dart';
+import 'appearance.dart';
 import 'binding.dart';
 import 'condition.dart';
 import 'contract.dart';
@@ -90,6 +91,7 @@ final class Design<V extends Vocabulary> {
   /// * duplicate assignments inside each binding;
   /// * vocabulary terms missing from a binding;
   /// * binding assignments that do not belong to the vocabulary;
+  /// * style appearance term references that do not belong to the vocabulary;
   /// * style parts, axes, and states that are not declared by the style contract.
   ///
   /// Each [Policy] then receives a [PolicyContext] for project-specific checks:
@@ -102,6 +104,7 @@ final class Design<V extends Vocabulary> {
   /// }
   /// ```
   List<Diagnostic> validate() {
+    final vocabularyIds = {for (final term in terms) term.id.value};
     final diagnostics = <Diagnostic>[
       ..._validateIdentifiers(kind: 'term', ids: terms.map((term) => term.id)),
       ..._validateIdentifiers(kind: 'binding', ids: bindings.map((b) => b.id)),
@@ -110,11 +113,11 @@ final class Design<V extends Vocabulary> {
 
     for (final binding in bindings) {
       diagnostics.addAll(binding.validate());
-      diagnostics.addAll(_validateBindingVocabulary(binding));
+      diagnostics.addAll(_validateBindingVocabulary(binding, vocabularyIds));
     }
 
     for (final style in styles) {
-      diagnostics.addAll(_validateStyle(style));
+      diagnostics.addAll(_validateStyle(style, vocabularyIds));
     }
 
     final context = _PolicyContext(this, diagnostics);
@@ -125,9 +128,11 @@ final class Design<V extends Vocabulary> {
     return diagnostics;
   }
 
-  List<Diagnostic> _validateBindingVocabulary(Binding binding) {
+  List<Diagnostic> _validateBindingVocabulary(
+    Binding binding,
+    Set<String> vocabularyIds,
+  ) {
     final diagnostics = <Diagnostic>[];
-    final vocabularyIds = {for (final term in terms) term.id.value};
     final assigned = {
       for (final assignment in binding.assignments) assignment.term.id.value,
     };
@@ -168,7 +173,7 @@ final class Design<V extends Vocabulary> {
     return diagnostics;
   }
 
-  List<Diagnostic> _validateStyle(Style style) {
+  List<Diagnostic> _validateStyle(Style style, Set<String> vocabularyIds) {
     final contract = style.contract;
     final diagnostics = <Diagnostic>[];
 
@@ -203,8 +208,50 @@ final class Design<V extends Vocabulary> {
       );
     }
 
+    diagnostics.addAll(
+      _validateAppearanceVocabulary(style, style.root, vocabularyIds),
+    );
+    for (final appearance in style.parts.values) {
+      diagnostics.addAll(
+        _validateAppearanceVocabulary(style, appearance, vocabularyIds),
+      );
+    }
     for (final styleCase in style.cases) {
       diagnostics.addAll(_validateCondition(style, contract, styleCase.when));
+      diagnostics.addAll(
+        _validateAppearanceVocabulary(
+          style,
+          styleCase.appearance,
+          vocabularyIds,
+        ),
+      );
+    }
+
+    return diagnostics;
+  }
+
+  List<Diagnostic> _validateAppearanceVocabulary(
+    Style style,
+    Appearance appearance,
+    Set<String> vocabularyIds,
+  ) {
+    final diagnostics = <Diagnostic>[];
+
+    for (final term in _appearanceTerms(appearance)) {
+      final termId = term.id.value;
+      if (vocabularyIds.contains(termId)) {
+        continue;
+      }
+
+      diagnostics.add(
+        Diagnostic(
+          code: DiagnosticCodes.styleUnknownTerm,
+          target: DiagnosticTarget(kind: 'term', name: termId),
+          message:
+              'Style `${style.id.value}` references term `$termId`, but this '
+              'term is not declared by the design vocabulary.',
+        ),
+      );
     }
 
     return diagnostics;
@@ -259,6 +306,56 @@ final class Design<V extends Vocabulary> {
       case Condition():
         return const [];
     }
+  }
+}
+
+Iterable<Term> _appearanceTerms(Appearance appearance) sync* {
+  final surface = appearance.surface;
+  if (surface != null) {
+    yield* _propertyTerms(surface.fill);
+    yield* _propertyTerms(surface.stroke);
+    yield* _propertyTerms(surface.radius);
+    yield* _propertyTerms(surface.elevation);
+  }
+
+  final content = appearance.content;
+  if (content != null) {
+    yield* _propertyTerms(content.color);
+    yield* _propertyTerms(content.text);
+    yield* _propertyTerms(content.icon);
+    yield* _propertyTerms(content.opacity);
+  }
+
+  final metrics = appearance.metrics;
+  if (metrics != null) {
+    yield* _insetTerms(metrics.padding);
+    yield* _propertyTerms(metrics.gap);
+    yield* _propertyTerms(metrics.width);
+    yield* _propertyTerms(metrics.height);
+    yield* _propertyTerms(metrics.minWidth);
+    yield* _propertyTerms(metrics.minHeight);
+    yield* _propertyTerms(metrics.maxWidth);
+    yield* _propertyTerms(metrics.maxHeight);
+  }
+}
+
+Iterable<Term> _insetTerms(Insets? insets) sync* {
+  if (insets == null) {
+    return;
+  }
+
+  yield* _propertyTerms(insets.top);
+  yield* _propertyTerms(insets.right);
+  yield* _propertyTerms(insets.bottom);
+  yield* _propertyTerms(insets.left);
+}
+
+Iterable<Term> _propertyTerms(Property<Object?>? property) sync* {
+  switch (property) {
+    case TermProperty<Object?>(:final term):
+      yield term;
+    case LiteralProperty<Object?>() || null:
+      return;
   }
 }
 

--- a/lib/src/style/design.dart
+++ b/lib/src/style/design.dart
@@ -106,7 +106,6 @@ final class Design<V extends Vocabulary> {
   /// ```
   List<Diagnostic> validate() {
     final vocabularyById = _termsById(terms);
-    final vocabularyIds = vocabularyById.keys.toSet();
     final diagnostics = <Diagnostic>[
       ..._validateIdentifiers(kind: 'term', ids: terms.map((term) => term.id)),
       ..._validateIdentifiers(kind: 'binding', ids: bindings.map((b) => b.id)),
@@ -119,7 +118,7 @@ final class Design<V extends Vocabulary> {
     }
 
     for (final style in styles) {
-      diagnostics.addAll(_validateStyle(style, vocabularyIds));
+      diagnostics.addAll(_validateStyle(style, vocabularyById));
     }
 
     final context = _PolicyContext(this, diagnostics);
@@ -154,7 +153,7 @@ final class Design<V extends Vocabulary> {
         continue;
       }
 
-      if (!vocabularyTerm.accepts(assignment.value)) {
+      if (!vocabularyTerm.acceptsValue(assignment.value)) {
         diagnostics.add(
           Diagnostic(
             code: DiagnosticCodes.designInvalidBindingValueType,
@@ -192,7 +191,10 @@ final class Design<V extends Vocabulary> {
     return diagnostics;
   }
 
-  List<Diagnostic> _validateStyle(Style style, Set<String> vocabularyIds) {
+  List<Diagnostic> _validateStyle(
+    Style style,
+    Map<String, Term> vocabularyById,
+  ) {
     final contract = style.contract;
     final diagnostics = <Diagnostic>[];
 
@@ -228,11 +230,11 @@ final class Design<V extends Vocabulary> {
     }
 
     diagnostics.addAll(
-      _validateAppearanceVocabulary(style, style.root, vocabularyIds),
+      _validateAppearanceVocabulary(style, style.root, vocabularyById),
     );
     for (final appearance in style.parts.values) {
       diagnostics.addAll(
-        _validateAppearanceVocabulary(style, appearance, vocabularyIds),
+        _validateAppearanceVocabulary(style, appearance, vocabularyById),
       );
     }
     for (final styleCase in style.cases) {
@@ -241,7 +243,7 @@ final class Design<V extends Vocabulary> {
         _validateAppearanceVocabulary(
           style,
           styleCase.appearance,
-          vocabularyIds,
+          vocabularyById,
         ),
       );
     }
@@ -252,25 +254,39 @@ final class Design<V extends Vocabulary> {
   List<Diagnostic> _validateAppearanceVocabulary(
     Style style,
     Appearance appearance,
-    Set<String> vocabularyIds,
+    Map<String, Term> vocabularyById,
   ) {
     final diagnostics = <Diagnostic>[];
 
     for (final term in _appearanceTerms(appearance)) {
       final termId = term.id.value;
-      if (vocabularyIds.contains(termId)) {
+      final vocabularyTerm = vocabularyById[termId];
+      if (vocabularyTerm == null) {
+        diagnostics.add(
+          Diagnostic(
+            code: DiagnosticCodes.styleUnknownTerm,
+            target: DiagnosticTarget(kind: 'term', name: termId),
+            message:
+                'Style `${style.id.value}` references term `$termId`, but this '
+                'term is not declared by the design vocabulary.',
+          ),
+        );
+
         continue;
       }
 
-      diagnostics.add(
-        Diagnostic(
-          code: DiagnosticCodes.styleUnknownTerm,
-          target: DiagnosticTarget(kind: 'term', name: termId),
-          message:
-              'Style `${style.id.value}` references term `$termId`, but this '
-              'term is not declared by the design vocabulary.',
-        ),
-      );
+      if (!vocabularyTerm.acceptsContract(term)) {
+        diagnostics.add(
+          Diagnostic(
+            code: DiagnosticCodes.styleInvalidTermType,
+            target: DiagnosticTarget(kind: 'term', name: termId),
+            message:
+                'Style `${style.id.value}` references term `$termId` as '
+                '${term.valueType}, but the design vocabulary declares that '
+                'term as ${vocabularyTerm.valueType}.',
+          ),
+        );
+      }
     }
 
     return diagnostics;
@@ -282,18 +298,30 @@ final class Design<V extends Vocabulary> {
     Condition condition,
   ) {
     switch (condition) {
-      case AxisCondition<Object?>(:final axis):
+      case AxisCondition<Object?>(:final axis, :final value):
+        final declaredAxis = contract?.axisNamed(axis.id);
         return [
           ...axis.id.validate(
             target: DiagnosticTarget(kind: 'axis', name: axis.id.value),
           ),
-          if (contract != null && !contract.allowsAxis(axis))
+          if (contract != null && declaredAxis == null)
             Diagnostic(
               code: DiagnosticCodes.styleUnknownAxis,
               target: DiagnosticTarget(kind: 'style', name: style.id.value),
               message:
                   'Style `${style.id.value}` uses axis `${axis.id.value}` that '
                   'is not present in its contract.',
+            ),
+          if (declaredAxis != null &&
+              (!declaredAxis.acceptsContract(axis) ||
+                  !declaredAxis.acceptsValue(value)))
+            Diagnostic(
+              code: DiagnosticCodes.styleInvalidAxisValueType,
+              target: DiagnosticTarget(kind: 'axis', name: axis.id.value),
+              message:
+                  'Style `${style.id.value}` uses a ${value.runtimeType} value '
+                  'for axis `${axis.id.value}`, but its contract declares that '
+                  'axis as ${declaredAxis.valueType}.',
             ),
         ];
       case State(:final id):

--- a/lib/src/style/design.dart
+++ b/lib/src/style/design.dart
@@ -1,0 +1,379 @@
+import 'axis.dart';
+import 'binding.dart';
+import 'condition.dart';
+import 'contract.dart';
+import 'diagnostic.dart';
+import 'identifier.dart';
+import 'state.dart';
+import 'style.dart';
+
+/// A platform-neutral manifest for one style system.
+///
+/// A design gathers the declarations that need to agree with each other: the
+/// typed terms object a system authors against, the bindings that give those
+/// terms values, the styles that consume appearances and contracts, and the
+/// custom policies a project wants to enforce.
+///
+/// ```dart
+/// const t = AppTerms();
+///
+/// final design = Design(
+///   terms: t,
+///   bindings: [
+///     Binding(Identifier('light'), [
+///       t.color.action.fill(const Color(0xff006adc)),
+///       t.radius.control(8.px),
+///     ]),
+///   ],
+///   styles: [
+///     Style<void>(
+///       id: Identifier('button'),
+///       root: Appearance(),
+///     ),
+///   ],
+///   policies: const [NoRawColorPolicy()],
+/// );
+///
+/// final diagnostics = design.validate();
+/// ```
+///
+/// Validation stays in the core model. It reports missing declarations and
+/// policy findings, but it does not project the design to CSS, Flutter, Material,
+/// Jaspr, or any other platform.
+final class Design {
+  /// Creates a style design manifest.
+  ///
+  /// All collections are copied into immutable lists. Mutating a source list
+  /// after construction will not change the design being validated.
+  Design({
+    required Vocabulary terms,
+    Iterable<Binding> bindings = const [],
+    Iterable<Style<Object?>> styles = const [],
+    Iterable<Policy> policies = const [],
+  }) : terms = terms,
+       vocabulary = List.unmodifiable(terms.terms),
+       bindings = List.unmodifiable(bindings),
+       styles = List.unmodifiable(styles),
+       policies = List.unmodifiable(policies);
+
+  /// The typed terms object used when authoring bindings and appearances.
+  ///
+  /// This is the same `t` object a package can expose to authors. It may be
+  /// written by hand or generated later, but it remains a normal Dart object.
+  final Vocabulary terms;
+
+  /// The flattened terms that bindings are expected to assign.
+  ///
+  /// [Design] derives this list from [terms] at construction time. It exists so
+  /// validators and policies can inspect the complete vocabulary without knowing
+  /// the shape of a project's typed term tree.
+  final List<Term<Object?>> vocabulary;
+
+  /// The named value sets available to resolve vocabulary terms.
+  final List<Binding> bindings;
+
+  /// The reusable style declarations in this design.
+  final List<Style<Object?>> styles;
+
+  /// Custom project rules that run after structural validation.
+  ///
+  /// Policies are ordinary Dart objects. They can inspect this design through a
+  /// [PolicyContext] and report diagnostics using their own stable codes.
+  final List<Policy> policies;
+
+  /// Returns structural and policy diagnostics for this design.
+  ///
+  /// Structural validation checks the relationships visible in the manifest:
+  ///
+  /// * identifier syntax for terms, bindings, assignments, axes, states, and
+  ///   styles;
+  /// * duplicate term, binding, and style identifiers;
+  /// * duplicate assignments inside each binding;
+  /// * vocabulary terms missing from a binding;
+  /// * style parts, axes, and states that are not declared by the style contract.
+  ///
+  /// Each [Policy] then receives a [PolicyContext] for project-specific checks:
+  ///
+  /// ```dart
+  /// final diagnostics = design.validate();
+  ///
+  /// if (diagnostics.any((diagnostic) => diagnostic.severity == .error)) {
+  ///   throw StateError('Design is not publishable.');
+  /// }
+  /// ```
+  List<Diagnostic> validate() {
+    final diagnostics = <Diagnostic>[
+      ..._validateIdentifiers(
+        kind: 'term',
+        ids: vocabulary.map((term) => term.id),
+      ),
+      ..._validateIdentifiers(kind: 'binding', ids: bindings.map((b) => b.id)),
+      ..._validateIdentifiers(kind: 'style', ids: styles.map((s) => s.id)),
+    ];
+
+    for (final binding in bindings) {
+      diagnostics.addAll(binding.validate());
+      diagnostics.addAll(_validateBindingCompleteness(binding));
+    }
+
+    for (final style in styles) {
+      diagnostics.addAll(_validateStyle(style));
+    }
+
+    final context = _PolicyContext(this, diagnostics);
+    for (final policy in policies) {
+      policy.evaluate(context);
+    }
+
+    return diagnostics;
+  }
+
+  List<Diagnostic> _validateBindingCompleteness(Binding binding) {
+    final diagnostics = <Diagnostic>[];
+    final assigned = {
+      for (final assignment in binding.assignments) assignment.term.id.value,
+    };
+
+    for (final term in vocabulary) {
+      if (assigned.contains(term.id.value)) {
+        continue;
+      }
+
+      diagnostics.add(
+        Diagnostic(
+          code: DiagnosticCodes.designMissingBindingValue,
+          target: DiagnosticTarget(kind: 'binding', name: binding.id.value),
+          message:
+              'Binding `${binding.id.value}` does not assign vocabulary term '
+              '`${term.id.value}`.',
+        ),
+      );
+    }
+
+    return diagnostics;
+  }
+
+  List<Diagnostic> _validateStyle(Style<Object?> style) {
+    final contract = style.contract;
+    final diagnostics = <Diagnostic>[];
+
+    if (contract != null) {
+      for (final entry in style.parts.entries) {
+        if (contract.allowsPart(entry.key)) {
+          continue;
+        }
+
+        diagnostics.add(
+          Diagnostic(
+            code: DiagnosticCodes.styleUnknownPart,
+            target: DiagnosticTarget(kind: 'style', name: style.id.value),
+            message:
+                'Style `${style.id.value}` declares part `${entry.key}` that is '
+                'not present in its contract.',
+          ),
+        );
+      }
+
+      diagnostics.addAll(
+        _validateIdentifiers(
+          kind: 'axis',
+          ids: contract.axes.map((axis) => axis.id),
+        ),
+      );
+      diagnostics.addAll(
+        _validateIdentifiers(
+          kind: 'state',
+          ids: contract.states.map((declaredState) => declaredState.id),
+        ),
+      );
+    }
+
+    for (final styleCase in style.cases) {
+      diagnostics.addAll(_validateCondition(style, contract, styleCase.when));
+    }
+
+    return diagnostics;
+  }
+
+  List<Diagnostic> _validateCondition(
+    Style<Object?> style,
+    Contract<Object?>? contract,
+    Condition condition,
+  ) {
+    switch (condition) {
+      case AxisCondition<Object?>(:final axis):
+        return [
+          ...axis.id.validate(
+            target: DiagnosticTarget(kind: 'axis', name: axis.id.value),
+          ),
+          if (contract != null && !contract.allowsAxis(axis))
+            Diagnostic(
+              code: DiagnosticCodes.styleUnknownAxis,
+              target: DiagnosticTarget(kind: 'style', name: style.id.value),
+              message:
+                  'Style `${style.id.value}` uses axis `${axis.id.value}` that '
+                  'is not present in its contract.',
+            ),
+        ];
+      case State(:final id):
+        return [
+          ...id.validate(
+            target: DiagnosticTarget(kind: 'state', name: id.value),
+          ),
+          if (contract != null && !contract.allowsState(condition))
+            Diagnostic(
+              code: DiagnosticCodes.styleUnknownState,
+              target: DiagnosticTarget(kind: 'style', name: style.id.value),
+              message:
+                  'Style `${style.id.value}` uses state `${id.value}` that is '
+                  'not present in its contract.',
+            ),
+        ];
+      case AllCondition(:final conditions):
+        return [
+          for (final child in conditions)
+            ..._validateCondition(style, contract, child),
+        ];
+      case AnyCondition(:final conditions):
+        return [
+          for (final child in conditions)
+            ..._validateCondition(style, contract, child),
+        ];
+      case NotCondition(:final condition):
+        return _validateCondition(style, contract, condition);
+      case Condition():
+        return const [];
+    }
+  }
+}
+
+/// A custom validation rule for a [Design].
+///
+/// Policies are normal Dart objects instead of function factories. That keeps
+/// configuration explicit, testable, and easy to share from extension packages:
+///
+/// ```dart
+/// final class NoRawColorPolicy implements Policy {
+///   const NoRawColorPolicy();
+///
+///   @override
+///   String get code => 'design.no_raw_color';
+///
+///   @override
+///   void evaluate(PolicyContext context) {
+///     // Inspect context.design and call context.report(...).
+///   }
+/// }
+/// ```
+abstract interface class Policy {
+  /// A stable identifier for this policy.
+  ///
+  /// Policy implementations may use this as a diagnostic code prefix or as a
+  /// configuration key. The core validator does not synthesize diagnostics from
+  /// it automatically, because each policy owns its own messages and severity.
+  String get code;
+
+  /// Evaluates this policy against [context].
+  void evaluate(PolicyContext context);
+}
+
+/// A typed term tree that can expose all of its vocabulary terms.
+///
+/// The public design API accepts `terms: t` so authoring code can keep using a
+/// domain-specific object such as `t.color.action.fill`. This protocol is the
+/// bridge that lets validation also enumerate those terms:
+///
+/// ```dart
+/// final class AppTerms implements Vocabulary {
+///   const AppTerms();
+///
+///   ColorTerms get color => const ColorTerms();
+///   RadiusTerms get radius => const RadiusTerms();
+///
+///   @override
+///   Iterable<Term<Object?>> get terms => [
+///     color.action.fill,
+///     radius.control,
+///   ];
+/// }
+/// ```
+///
+/// Future generators can produce the same ordinary Dart shape. They do not need
+/// to introduce a second style language or hidden runtime registry.
+abstract interface class Vocabulary {
+  /// Every term that belongs to this vocabulary.
+  Iterable<Term<Object?>> get terms;
+}
+
+/// The reporting surface passed to [Policy.evaluate].
+///
+/// A policy context exposes the current [design] and a single [report] method.
+/// Policies should report all findings they can discover in one pass instead of
+/// throwing at the first violation.
+abstract interface class PolicyContext {
+  /// The design being evaluated.
+  Design get design;
+
+  /// Adds [diagnostic] to the result returned by [Design.validate].
+  void report(Diagnostic diagnostic);
+}
+
+final class _PolicyContext implements PolicyContext {
+  _PolicyContext(this.design, this._diagnostics);
+
+  @override
+  final Design design;
+
+  final List<Diagnostic> _diagnostics;
+
+  @override
+  void report(Diagnostic diagnostic) {
+    _diagnostics.add(diagnostic);
+  }
+}
+
+List<Diagnostic> _validateIdentifiers({
+  required String kind,
+  required Iterable<Identifier> ids,
+}) {
+  final diagnostics = <Diagnostic>[];
+  final seen = <String, Identifier>{};
+  final seenIgnoringCase = <String, Identifier>{};
+
+  for (final id in ids) {
+    final target = DiagnosticTarget(kind: kind, name: id.value);
+
+    diagnostics.addAll(id.validate(target: target));
+
+    final duplicate = seen[id.value];
+    if (duplicate != null) {
+      diagnostics.add(
+        Diagnostic(
+          code: DiagnosticCodes.identifierDuplicate,
+          target: target,
+          message: '$kind `${id.value}` is already defined.',
+        ),
+      );
+    } else {
+      seen[id.value] = id;
+    }
+
+    final folded = id.value.toLowerCase();
+    final caseDuplicate = seenIgnoringCase[folded];
+    if (caseDuplicate != null && caseDuplicate.value != id.value) {
+      diagnostics.add(
+        Diagnostic(
+          code: DiagnosticCodes.identifierDuplicateIgnoringCase,
+          target: target,
+          message:
+              '$kind `${id.value}` conflicts with `${caseDuplicate.value}` '
+              'when compared case-insensitively.',
+        ),
+      );
+    } else {
+      seenIgnoringCase[folded] = id;
+    }
+  }
+
+  return diagnostics;
+}

--- a/lib/src/style/diagnostic.dart
+++ b/lib/src/style/diagnostic.dart
@@ -48,6 +48,14 @@ abstract final class DiagnosticCodes {
   static const bindingDuplicateAssignmentIgnoringCase =
       'binding.duplicate_assignment_ignoring_case';
 
+  /// A binding does not assign a term declared by the design vocabulary.
+  ///
+  /// Design validation reports this when a [Design] knows the complete vocabulary
+  /// and can compare every [Binding] against it. A binding can still be validated
+  /// on its own without reporting this code, because local binding validation
+  /// does not know which terms are required.
+  static const designMissingBindingValue = 'design.missing_binding_value';
+
   /// An empty [Identifier.value].
   static const identifierEmpty = 'identifier.empty';
 
@@ -73,6 +81,18 @@ abstract final class DiagnosticCodes {
   /// namespace. It is not a lexical error for a single [Identifier].
   static const identifierDuplicateIgnoringCase =
       'identifier.duplicate_ignoring_case';
+
+  /// A style declares a part that is not present in its contract.
+  ///
+  /// Contract validation is owned by the style because parts are only meaningful
+  /// through the style's part type.
+  static const styleUnknownPart = 'style.unknown_part';
+
+  /// A style case uses an axis that is not present in its contract.
+  static const styleUnknownAxis = 'style.unknown_axis';
+
+  /// A style case uses a state that is not present in its contract.
+  static const styleUnknownState = 'style.unknown_state';
 }
 
 /// A non-throwing validation result for style declarations.

--- a/lib/src/style/diagnostic.dart
+++ b/lib/src/style/diagnostic.dart
@@ -64,6 +64,15 @@ abstract final class DiagnosticCodes {
   /// sets from passing manifest validation.
   static const designUnknownBindingValue = 'design.unknown_binding_value';
 
+  /// A binding assigns a value that does not match its vocabulary term type.
+  ///
+  /// Design validation reports this when an assignment has the same identifier
+  /// as a vocabulary [Term], but the authored value is not accepted by that term.
+  /// This catches declarations that bypass the typed term object with another
+  /// term using the same identifier and an incompatible type argument.
+  static const designInvalidBindingValueType =
+      'design.invalid_binding_value_type';
+
   /// An empty [Identifier.value].
   static const identifierEmpty = 'identifier.empty';
 

--- a/lib/src/style/diagnostic.dart
+++ b/lib/src/style/diagnostic.dart
@@ -56,6 +56,14 @@ abstract final class DiagnosticCodes {
   /// does not know which terms are required.
   static const designMissingBindingValue = 'design.missing_binding_value';
 
+  /// A binding assigns a term outside the design vocabulary.
+  ///
+  /// Design validation reports this when a [Binding] contains an assignment for
+  /// a foreign or misspelled [Term]. Keeping this at the design layer lets
+  /// bindings stay reusable while still preventing complete-but-invalid token
+  /// sets from passing manifest validation.
+  static const designUnknownBindingValue = 'design.unknown_binding_value';
+
   /// An empty [Identifier.value].
   static const identifierEmpty = 'identifier.empty';
 

--- a/lib/src/style/diagnostic.dart
+++ b/lib/src/style/diagnostic.dart
@@ -113,8 +113,23 @@ abstract final class DiagnosticCodes {
   /// validated bindings unless every referenced term belongs to the vocabulary.
   static const styleUnknownTerm = 'style.unknown_term';
 
+  /// A style appearance references a term with the wrong value type.
+  ///
+  /// Design validation reports this when a style term reference has the same
+  /// identifier as a vocabulary [Term], but its type argument does not match the
+  /// vocabulary term. This protects resolvers from reading a valid binding value
+  /// through a style property that expects a different value type.
+  static const styleInvalidTermType = 'style.invalid_term_type';
+
   /// A style case uses an axis that is not present in its contract.
   static const styleUnknownAxis = 'style.unknown_axis';
+
+  /// A style case uses an axis value that does not match its contract axis type.
+  ///
+  /// Design validation reports this when a condition uses an [Axis] with the
+  /// same identifier as a contract axis but with an incompatible type argument
+  /// or value.
+  static const styleInvalidAxisValueType = 'style.invalid_axis_value_type';
 
   /// A style case uses a state that is not present in its contract.
   static const styleUnknownState = 'style.unknown_state';

--- a/lib/src/style/diagnostic.dart
+++ b/lib/src/style/diagnostic.dart
@@ -96,6 +96,14 @@ abstract final class DiagnosticCodes {
   /// through the style's part type.
   static const styleUnknownPart = 'style.unknown_part';
 
+  /// A style appearance references a term outside the design vocabulary.
+  ///
+  /// Design validation reports this when a [Property.term] inside a style root,
+  /// part, or case appearance points at a foreign or misspelled [Term]. The
+  /// style may still be structurally valid, but it cannot be resolved from the
+  /// validated bindings unless every referenced term belongs to the vocabulary.
+  static const styleUnknownTerm = 'style.unknown_term';
+
   /// A style case uses an axis that is not present in its contract.
   static const styleUnknownAxis = 'style.unknown_axis';
 

--- a/lib/src/style/value_contract.dart
+++ b/lib/src/style/value_contract.dart
@@ -1,0 +1,27 @@
+import 'identifier.dart';
+
+/// A typed declaration that can validate values after generic type widening.
+///
+/// Core style declarations are authored with static Dart types, but validators
+/// often receive them through wider surfaces such as `Term`, `Axis<Object?>`, or
+/// `Assignment<Object?>`. A value contract preserves the runtime pieces needed
+/// to check those widened declarations without guessing from identifiers alone.
+///
+/// [Term] and [Axis] both implement this contract. A validator can first match
+/// declarations by [id], then use [acceptsContract] and [acceptsValue] to reject
+/// declarations that reuse an identifier with the wrong value type.
+abstract interface class ValueContract<T> {
+  /// The authoring name used for validation, diagnostics, and future tooling.
+  Identifier get id;
+
+  /// The runtime type represented by this declaration.
+  Type get valueType;
+
+  /// Whether [value] can be used with this declaration.
+  bool acceptsValue(Object? value);
+
+  /// Whether [contract] names this same typed declaration.
+  ///
+  /// Compatible contracts must have the same [id] and [valueType].
+  bool acceptsContract(ValueContract<Object?> contract);
+}

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -29,6 +29,7 @@ export 'src/style/case.dart';
 export 'src/style/color.dart';
 export 'src/style/condition.dart';
 export 'src/style/contract.dart';
+export 'src/style/design.dart';
 export 'src/style/diagnostic.dart';
 export 'src/style/dimension.dart';
 export 'src/style/identifier.dart';

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -35,3 +35,4 @@ export 'src/style/dimension.dart';
 export 'src/style/identifier.dart';
 export 'src/style/state.dart';
 export 'src/style/style.dart';
+export 'src/style/value_contract.dart';

--- a/test/style/_utils.dart
+++ b/test/style/_utils.dart
@@ -1,8 +1,32 @@
 import 'package:odroe/style.dart';
 import 'package:test/test.dart';
 
-Matcher containsDiagnosticCode(String code) {
-  return contains(
-    isA<Diagnostic>().having((diagnostic) => diagnostic.code, 'code', code),
+Matcher containsDiagnostic({
+  required String code,
+  String? targetKind,
+  String? targetName,
+}) {
+  var matcher = isA<Diagnostic>().having(
+    (diagnostic) => diagnostic.code,
+    'code',
+    code,
   );
+
+  if (targetKind != null) {
+    matcher = matcher.having(
+      (diagnostic) => diagnostic.target?.kind,
+      'target.kind',
+      targetKind,
+    );
+  }
+
+  if (targetName != null) {
+    matcher = matcher.having(
+      (diagnostic) => diagnostic.target?.name,
+      'target.name',
+      targetName,
+    );
+  }
+
+  return contains(matcher);
 }

--- a/test/style/binding_test.dart
+++ b/test/style/binding_test.dart
@@ -53,12 +53,12 @@ void main() {
 
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.bindingDuplicateAssignment),
+      containsDiagnostic(code: DiagnosticCodes.bindingDuplicateAssignment),
     );
     expect(
       diagnostics,
-      containsDiagnosticCode(
-        DiagnosticCodes.bindingDuplicateAssignmentIgnoringCase,
+      containsDiagnostic(
+        code: DiagnosticCodes.bindingDuplicateAssignmentIgnoringCase,
       ),
     );
   });

--- a/test/style/contract_test.dart
+++ b/test/style/contract_test.dart
@@ -32,6 +32,10 @@ void main() {
       id: Identifier('button.tone'),
       defaultValue: ButtonTone.primary,
     );
+    const stringTone = Axis<String>(
+      id: Identifier('button.tone'),
+      defaultValue: 'primary',
+    );
     const otherTone = Axis<ButtonTone>(
       id: Identifier('button.intent'),
       defaultValue: ButtonTone.primary,
@@ -45,7 +49,10 @@ void main() {
 
     expect(contract.allowsPart(ButtonPart.icon), isTrue);
     expect(contract.allowsPart(ButtonPart.label), isFalse);
+    expect(contract.axisNamed(tone.id), same(tone));
+    expect(contract.axisNamed(otherTone.id), isNull);
     expect(contract.allowsAxis(sameTone), isTrue);
+    expect(contract.allowsAxis(stringTone), isFalse);
     expect(contract.allowsAxis(otherTone), isFalse);
     expect(
       contract.allowsState(const State(Identifier('state.hovered'))),

--- a/test/style/design_test.dart
+++ b/test/style/design_test.dart
@@ -38,30 +38,86 @@ void main() {
     expect(() => design.bindings.clear(), throwsUnsupportedError);
   });
 
-  test('reports duplicate identifiers across manifest namespaces', () {
+  test('reports duplicate vocabulary term identifiers', () {
     const fill = Term<Color>(Identifier('color.action.fill'));
     const sameFill = Term<Color>(Identifier('color.action.fill'));
     const caseFill = Term<Color>(Identifier('Color.Action.Fill'));
 
     final diagnostics = Design(
       vocabulary: const _TermListVocabulary(<Term>[fill, sameFill, caseFill]),
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.identifierDuplicate,
+        targetKind: 'term',
+        targetName: 'color.action.fill',
+      ),
+    );
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.identifierDuplicateIgnoringCase,
+        targetKind: 'term',
+        targetName: 'Color.Action.Fill',
+      ),
+    );
+  });
+
+  test('reports duplicate binding identifiers', () {
+    final diagnostics = Design(
+      vocabulary: const _TermListVocabulary(),
       bindings: [
-        Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
-        Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
-      ],
-      styles: [
-        Style<void>(id: Identifier('button'), root: const Appearance()),
-        Style<void>(id: Identifier('button'), root: const Appearance()),
+        Binding(Identifier('light'), const []),
+        Binding(Identifier('light'), const []),
+        Binding(Identifier('Light'), const []),
       ],
     ).validate();
 
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.identifierDuplicate),
+      containsDiagnostic(
+        code: DiagnosticCodes.identifierDuplicate,
+        targetKind: 'binding',
+        targetName: 'light',
+      ),
     );
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.identifierDuplicateIgnoringCase),
+      containsDiagnostic(
+        code: DiagnosticCodes.identifierDuplicateIgnoringCase,
+        targetKind: 'binding',
+        targetName: 'Light',
+      ),
+    );
+  });
+
+  test('reports duplicate style identifiers', () {
+    final diagnostics = Design(
+      vocabulary: const _TermListVocabulary(),
+      styles: [
+        Style<void>(id: Identifier('button'), root: const Appearance()),
+        Style<void>(id: Identifier('button'), root: const Appearance()),
+        Style<void>(id: Identifier('Button'), root: const Appearance()),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.identifierDuplicate,
+        targetKind: 'style',
+        targetName: 'button',
+      ),
+    );
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.identifierDuplicateIgnoringCase,
+        targetKind: 'style',
+        targetName: 'Button',
+      ),
     );
   });
 
@@ -79,7 +135,39 @@ void main() {
 
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.designMissingBindingValue),
+      containsDiagnostic(code: DiagnosticCodes.designMissingBindingValue),
+    );
+  });
+
+  test('reports binding assignments outside the vocabulary', () {
+    const t = _AppTerms();
+    const brandFill = Term<Color>(Identifier('color.brand.fill'));
+
+    final diagnostics = Design(
+      vocabulary: t,
+      bindings: [
+        Binding(Identifier('light'), [
+          t.color.action.fill(const Color(0xff006adc)),
+          t.color.action.content(const Color(0xffffffff)),
+          t.radius.control(8.px),
+          brandFill(const Color(0xff123456)),
+        ]),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.designUnknownBindingValue,
+        targetKind: 'assignment',
+        targetName: 'color.brand.fill',
+      ),
+    );
+    expect(
+      diagnostics,
+      isNot(
+        containsDiagnostic(code: DiagnosticCodes.designMissingBindingValue),
+      ),
     );
   });
 
@@ -98,7 +186,7 @@ void main() {
 
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.bindingDuplicateAssignment),
+      containsDiagnostic(code: DiagnosticCodes.bindingDuplicateAssignment),
     );
   });
 
@@ -135,15 +223,15 @@ void main() {
 
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.styleUnknownPart),
+      containsDiagnostic(code: DiagnosticCodes.styleUnknownPart),
     );
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.styleUnknownAxis),
+      containsDiagnostic(code: DiagnosticCodes.styleUnknownAxis),
     );
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.styleUnknownState),
+      containsDiagnostic(code: DiagnosticCodes.styleUnknownState),
     );
   });
 
@@ -172,11 +260,11 @@ void main() {
 
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.identifierInvalidSegment),
+      containsDiagnostic(code: DiagnosticCodes.identifierInvalidSegment),
     );
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.identifierEmptySegment),
+      containsDiagnostic(code: DiagnosticCodes.identifierEmptySegment),
     );
   });
 
@@ -207,7 +295,7 @@ void main() {
 
     expect(
       diagnostics,
-      containsDiagnosticCode(DiagnosticCodes.identifierDuplicate),
+      containsDiagnostic(code: DiagnosticCodes.identifierDuplicate),
     );
   });
 
@@ -217,7 +305,10 @@ void main() {
       policies: const [_AlwaysReportPolicy()],
     ).validate();
 
-    expect(diagnostics, containsDiagnosticCode(_AlwaysReportPolicy.codeValue));
+    expect(
+      diagnostics,
+      containsDiagnostic(code: _AlwaysReportPolicy.codeValue),
+    );
   });
 }
 

--- a/test/style/design_test.dart
+++ b/test/style/design_test.dart
@@ -1,0 +1,241 @@
+import 'package:odroe/style.dart';
+import 'package:test/test.dart';
+
+import '_utils.dart';
+
+enum ButtonPart { icon, label }
+
+enum ButtonTone { primary, danger }
+
+void main() {
+  test('stores manifest collections in immutable lists', () {
+    const fill = Term<Color>(Identifier('color.action.fill'));
+    final vocabulary = <Term<Object?>>[fill];
+    final terms = _TestVocabulary(vocabulary);
+    final bindings = [
+      Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
+    ];
+    final styles = [
+      Style<void>(id: Identifier('button'), root: const Appearance()),
+    ];
+
+    final design = Design(terms: terms, bindings: bindings, styles: styles);
+    vocabulary.clear();
+    bindings.clear();
+    styles.clear();
+
+    expect(design.terms, same(terms));
+    expect(design.vocabulary, [fill]);
+    expect(design.bindings, hasLength(1));
+    expect(design.styles, hasLength(1));
+    expect(() => design.vocabulary.clear(), throwsUnsupportedError);
+    expect(() => design.bindings.clear(), throwsUnsupportedError);
+  });
+
+  test('reports duplicate identifiers across manifest namespaces', () {
+    const fill = Term<Color>(Identifier('color.action.fill'));
+    const sameFill = Term<Color>(Identifier('color.action.fill'));
+    const caseFill = Term<Color>(Identifier('Color.Action.Fill'));
+
+    final diagnostics = Design(
+      terms: const _TestVocabulary(<Term<Object?>>[fill, sameFill, caseFill]),
+      bindings: [
+        Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
+        Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
+      ],
+      styles: [
+        Style<void>(id: Identifier('button'), root: const Appearance()),
+        Style<void>(id: Identifier('button'), root: const Appearance()),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.identifierDuplicate),
+    );
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.identifierDuplicateIgnoringCase),
+    );
+  });
+
+  test('reports missing vocabulary terms in bindings', () {
+    const fill = Term<Color>(Identifier('color.action.fill'));
+    const content = Term<Color>(Identifier('color.action.content'));
+
+    final diagnostics = Design(
+      terms: const _TestVocabulary(<Term<Object?>>[fill, content]),
+      bindings: [
+        Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.designMissingBindingValue),
+    );
+  });
+
+  test('keeps binding-level duplicate assignment diagnostics', () {
+    const fill = Term<Color>(Identifier('color.action.fill'));
+
+    final diagnostics = Design(
+      terms: const _TestVocabulary(<Term<Object?>>[fill]),
+      bindings: [
+        Binding(Identifier('light'), [
+          fill(const Color(0xff006adc)),
+          fill(const Color(0xff0055aa)),
+        ]),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.bindingDuplicateAssignment),
+    );
+  });
+
+  test('reports style members not declared by the contract', () {
+    const tone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    const density = Axis<int>(
+      id: Identifier('button.density'),
+      defaultValue: 0,
+    );
+    final contract = Contract<ButtonPart>(
+      parts: {ButtonPart.icon},
+      axes: [tone],
+      states: {state.hovered},
+    );
+
+    final diagnostics = Design(
+      terms: const _TestVocabulary(),
+      styles: [
+        Style<ButtonPart>(
+          id: Identifier('button'),
+          contract: contract,
+          root: const Appearance(),
+          parts: const {ButtonPart.label: Appearance()},
+          cases: [
+            .when(density(1), const Appearance()),
+            .when(state.disabled, const Appearance()),
+          ],
+        ),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.styleUnknownPart),
+    );
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.styleUnknownAxis),
+    );
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.styleUnknownState),
+    );
+  });
+
+  test('validates condition identifiers without requiring a contract', () {
+    const invalidAxis = Axis<int>(
+      id: Identifier('button-axis'),
+      defaultValue: 0,
+    );
+
+    final diagnostics = Design(
+      terms: const _TestVocabulary(),
+      styles: [
+        Style<void>(
+          id: Identifier('button'),
+          root: const Appearance(),
+          cases: [
+            .when(invalidAxis(1), const Appearance()),
+            .when(
+              const State(Identifier('state..hovered')),
+              const Appearance(),
+            ),
+          ],
+        ),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.identifierInvalidSegment),
+    );
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.identifierEmptySegment),
+    );
+  });
+
+  test('reports duplicate contract axis and state identifiers', () {
+    const tone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    const sameTone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.danger,
+    );
+    const hovered = State(Identifier('state.hovered'));
+
+    final diagnostics = Design(
+      terms: const _TestVocabulary(),
+      styles: [
+        Style<ButtonPart>(
+          id: Identifier('button'),
+          contract: Contract<ButtonPart>(
+            axes: [tone, sameTone],
+            states: {hovered, state.hovered},
+          ),
+          root: const Appearance(),
+        ),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnosticCode(DiagnosticCodes.identifierDuplicate),
+    );
+  });
+
+  test('runs custom policy objects', () {
+    final diagnostics = Design(
+      terms: const _TestVocabulary(),
+      policies: const [_AlwaysReportPolicy()],
+    ).validate();
+
+    expect(diagnostics, containsDiagnosticCode(_AlwaysReportPolicy.codeValue));
+  });
+}
+
+final class _TestVocabulary implements Vocabulary {
+  const _TestVocabulary([this.terms = const []]);
+
+  @override
+  final List<Term<Object?>> terms;
+}
+
+final class _AlwaysReportPolicy implements Policy {
+  const _AlwaysReportPolicy();
+
+  static const codeValue = 'design.always_report';
+
+  @override
+  String get code => codeValue;
+
+  @override
+  void evaluate(PolicyContext context) {
+    context.report(
+      const Diagnostic(
+        code: codeValue,
+        message: 'Policy reported a diagnostic.',
+      ),
+    );
+  }
+}

--- a/test/style/design_test.dart
+++ b/test/style/design_test.dart
@@ -9,23 +9,28 @@ enum ButtonTone { primary, danger }
 
 void main() {
   test('stores manifest collections in immutable lists', () {
-    const fill = Term<Color>(Identifier('color.action.fill'));
-    final vocabulary = <Term<Object?>>[fill];
-    final terms = _TestVocabulary(vocabulary);
+    const t = _AppTerms();
     final bindings = [
-      Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
+      Binding(Identifier('light'), [
+        t.color.action.fill(const Color(0xff006adc)),
+        t.color.action.content(const Color(0xffffffff)),
+        t.radius.control(8.px),
+      ]),
     ];
     final styles = [
       Style<void>(id: Identifier('button'), root: const Appearance()),
     ];
 
-    final design = Design(terms: terms, bindings: bindings, styles: styles);
-    vocabulary.clear();
+    final design = Design(terms: t, bindings: bindings, styles: styles);
     bindings.clear();
     styles.clear();
 
-    expect(design.terms, same(terms));
-    expect(design.vocabulary, [fill]);
+    expect(design.terms, same(t));
+    expect(design.vocabulary, [
+      t.color.action.fill,
+      t.color.action.content,
+      t.radius.control,
+    ]);
     expect(design.bindings, hasLength(1));
     expect(design.styles, hasLength(1));
     expect(() => design.vocabulary.clear(), throwsUnsupportedError);
@@ -38,7 +43,7 @@ void main() {
     const caseFill = Term<Color>(Identifier('Color.Action.Fill'));
 
     final diagnostics = Design(
-      terms: const _TestVocabulary(<Term<Object?>>[fill, sameFill, caseFill]),
+      terms: const _TermListVocabulary(<Term>[fill, sameFill, caseFill]),
       bindings: [
         Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
         Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
@@ -60,13 +65,14 @@ void main() {
   });
 
   test('reports missing vocabulary terms in bindings', () {
-    const fill = Term<Color>(Identifier('color.action.fill'));
-    const content = Term<Color>(Identifier('color.action.content'));
+    const t = _AppTerms();
 
     final diagnostics = Design(
-      terms: const _TestVocabulary(<Term<Object?>>[fill, content]),
+      terms: t,
       bindings: [
-        Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
+        Binding(Identifier('light'), [
+          t.color.action.fill(const Color(0xff006adc)),
+        ]),
       ],
     ).validate();
 
@@ -80,7 +86,7 @@ void main() {
     const fill = Term<Color>(Identifier('color.action.fill'));
 
     final diagnostics = Design(
-      terms: const _TestVocabulary(<Term<Object?>>[fill]),
+      terms: const _TermListVocabulary(<Term>[fill]),
       bindings: [
         Binding(Identifier('light'), [
           fill(const Color(0xff006adc)),
@@ -111,7 +117,7 @@ void main() {
     );
 
     final diagnostics = Design(
-      terms: const _TestVocabulary(),
+      terms: const _TermListVocabulary(),
       styles: [
         Style<ButtonPart>(
           id: Identifier('button'),
@@ -147,7 +153,7 @@ void main() {
     );
 
     final diagnostics = Design(
-      terms: const _TestVocabulary(),
+      terms: const _TermListVocabulary(),
       styles: [
         Style<void>(
           id: Identifier('button'),
@@ -185,7 +191,7 @@ void main() {
     const hovered = State(Identifier('state.hovered'));
 
     final diagnostics = Design(
-      terms: const _TestVocabulary(),
+      terms: const _TermListVocabulary(),
       styles: [
         Style<ButtonPart>(
           id: Identifier('button'),
@@ -206,7 +212,7 @@ void main() {
 
   test('runs custom policy objects', () {
     final diagnostics = Design(
-      terms: const _TestVocabulary(),
+      terms: const _TermListVocabulary(),
       policies: const [_AlwaysReportPolicy()],
     ).validate();
 
@@ -214,11 +220,46 @@ void main() {
   });
 }
 
-final class _TestVocabulary implements Vocabulary {
-  const _TestVocabulary([this.terms = const []]);
+final class _AppTerms implements Vocabulary {
+  const _AppTerms();
+
+  _ColorTerms get color => const _ColorTerms();
+
+  _RadiusTerms get radius => const _RadiusTerms();
 
   @override
-  final List<Term<Object?>> terms;
+  Iterable<Term> get terms => [
+    color.action.fill,
+    color.action.content,
+    radius.control,
+  ];
+}
+
+final class _ColorTerms {
+  const _ColorTerms();
+
+  _ActionColorTerms get action => const _ActionColorTerms();
+}
+
+final class _ActionColorTerms {
+  const _ActionColorTerms();
+
+  Term<Color> get fill => const Term(Identifier('color.action.fill'));
+
+  Term<Color> get content => const Term(Identifier('color.action.content'));
+}
+
+final class _RadiusTerms {
+  const _RadiusTerms();
+
+  Term<Dimension> get control => const Term(Identifier('radius.control'));
+}
+
+final class _TermListVocabulary implements Vocabulary {
+  const _TermListVocabulary([this.terms = const []]);
+
+  @override
+  final List<Term> terms;
 }
 
 final class _AlwaysReportPolicy implements Policy {

--- a/test/style/design_test.dart
+++ b/test/style/design_test.dart
@@ -259,6 +259,40 @@ void main() {
     );
   });
 
+  test('reports style term references with incompatible value types', () {
+    const t = _AppTerms();
+    const wrongRadius = Term<Color>(Identifier('radius.control'));
+
+    final diagnostics = Design(
+      vocabulary: t,
+      styles: [
+        Style<void>(
+          id: Identifier('button'),
+          root: const Appearance(surface: Surface(fill: .term(wrongRadius))),
+        ),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.styleInvalidTermType,
+        targetKind: 'term',
+        targetName: 'radius.control',
+      ),
+    );
+    expect(
+      diagnostics,
+      isNot(
+        containsDiagnostic(
+          code: DiagnosticCodes.styleUnknownTerm,
+          targetKind: 'term',
+          targetName: 'radius.control',
+        ),
+      ),
+    );
+  });
+
   test('keeps binding-level duplicate assignment diagnostics', () {
     const fill = Term<Color>(Identifier('color.action.fill'));
 
@@ -320,6 +354,47 @@ void main() {
     expect(
       diagnostics,
       containsDiagnostic(code: DiagnosticCodes.styleUnknownState),
+    );
+  });
+
+  test('reports condition axes with incompatible value types', () {
+    const tone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    const stringTone = Axis<String>(
+      id: Identifier('button.tone'),
+      defaultValue: 'primary',
+    );
+
+    final diagnostics = Design(
+      vocabulary: const _TermListVocabulary(),
+      styles: [
+        Style<void>(
+          id: Identifier('button'),
+          contract: Contract<void>(axes: [tone]),
+          root: const Appearance(),
+          cases: [.when(stringTone('danger'), const Appearance())],
+        ),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.styleInvalidAxisValueType,
+        targetKind: 'axis',
+        targetName: 'button.tone',
+      ),
+    );
+    expect(
+      diagnostics,
+      isNot(
+        containsDiagnostic(
+          code: DiagnosticCodes.styleUnknownAxis,
+          targetName: 'button.tone',
+        ),
+      ),
     );
   });
 

--- a/test/style/design_test.dart
+++ b/test/style/design_test.dart
@@ -171,6 +171,35 @@ void main() {
     );
   });
 
+  test('reports binding assignments with incompatible value types', () {
+    const t = _AppTerms();
+    const wrongFill = Term<Dimension>(Identifier('color.action.fill'));
+
+    final diagnostics = Design(
+      vocabulary: t,
+      bindings: [
+        Binding(Identifier('light'), [
+          wrongFill(8.px),
+          t.color.action.content(const Color(0xffffffff)),
+          t.radius.control(8.px),
+        ]),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.designInvalidBindingValueType,
+        targetKind: 'assignment',
+        targetName: 'color.action.fill',
+      ),
+    );
+    expect(
+      diagnostics,
+      containsDiagnostic(code: DiagnosticCodes.designMissingBindingValue),
+    );
+  });
+
   test('reports style term references outside the vocabulary', () {
     const t = _AppTerms();
     const brandFill = Term<Color>(Identifier('color.brand.fill'));

--- a/test/style/design_test.dart
+++ b/test/style/design_test.dart
@@ -21,19 +21,20 @@ void main() {
       Style<void>(id: Identifier('button'), root: const Appearance()),
     ];
 
-    final design = Design(terms: t, bindings: bindings, styles: styles);
+    final design = Design(vocabulary: t, bindings: bindings, styles: styles);
     bindings.clear();
     styles.clear();
 
-    expect(design.terms, same(t));
-    expect(design.vocabulary, [
+    expect(design.vocabulary, same(t));
+    expect(design.vocabulary.color.action.fill.id.value, 'color.action.fill');
+    expect(design.terms, [
       t.color.action.fill,
       t.color.action.content,
       t.radius.control,
     ]);
     expect(design.bindings, hasLength(1));
     expect(design.styles, hasLength(1));
-    expect(() => design.vocabulary.clear(), throwsUnsupportedError);
+    expect(() => design.terms.clear(), throwsUnsupportedError);
     expect(() => design.bindings.clear(), throwsUnsupportedError);
   });
 
@@ -43,7 +44,7 @@ void main() {
     const caseFill = Term<Color>(Identifier('Color.Action.Fill'));
 
     final diagnostics = Design(
-      terms: const _TermListVocabulary(<Term>[fill, sameFill, caseFill]),
+      vocabulary: const _TermListVocabulary(<Term>[fill, sameFill, caseFill]),
       bindings: [
         Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
         Binding(Identifier('light'), [fill(const Color(0xff006adc))]),
@@ -68,7 +69,7 @@ void main() {
     const t = _AppTerms();
 
     final diagnostics = Design(
-      terms: t,
+      vocabulary: t,
       bindings: [
         Binding(Identifier('light'), [
           t.color.action.fill(const Color(0xff006adc)),
@@ -86,7 +87,7 @@ void main() {
     const fill = Term<Color>(Identifier('color.action.fill'));
 
     final diagnostics = Design(
-      terms: const _TermListVocabulary(<Term>[fill]),
+      vocabulary: const _TermListVocabulary(<Term>[fill]),
       bindings: [
         Binding(Identifier('light'), [
           fill(const Color(0xff006adc)),
@@ -117,7 +118,7 @@ void main() {
     );
 
     final diagnostics = Design(
-      terms: const _TermListVocabulary(),
+      vocabulary: const _TermListVocabulary(),
       styles: [
         Style<ButtonPart>(
           id: Identifier('button'),
@@ -153,7 +154,7 @@ void main() {
     );
 
     final diagnostics = Design(
-      terms: const _TermListVocabulary(),
+      vocabulary: const _TermListVocabulary(),
       styles: [
         Style<void>(
           id: Identifier('button'),
@@ -191,7 +192,7 @@ void main() {
     const hovered = State(Identifier('state.hovered'));
 
     final diagnostics = Design(
-      terms: const _TermListVocabulary(),
+      vocabulary: const _TermListVocabulary(),
       styles: [
         Style<ButtonPart>(
           id: Identifier('button'),
@@ -212,7 +213,7 @@ void main() {
 
   test('runs custom policy objects', () {
     final diagnostics = Design(
-      terms: const _TermListVocabulary(),
+      vocabulary: const _TermListVocabulary(),
       policies: const [_AlwaysReportPolicy()],
     ).validate();
 

--- a/test/style/design_test.dart
+++ b/test/style/design_test.dart
@@ -171,6 +171,65 @@ void main() {
     );
   });
 
+  test('reports style term references outside the vocabulary', () {
+    const t = _AppTerms();
+    const brandFill = Term<Color>(Identifier('color.brand.fill'));
+    const brandRadius = Term<Dimension>(Identifier('radius.brand'));
+
+    final diagnostics = Design(
+      vocabulary: t,
+      styles: [
+        Style<ButtonPart>(
+          id: Identifier('button'),
+          root: Appearance(
+            surface: Surface(fill: .term(brandFill)),
+            content: Content(color: .term(t.color.action.content)),
+          ),
+          parts: {
+            ButtonPart.icon: Appearance(
+              surface: Surface(radius: .term(brandRadius)),
+            ),
+          },
+          cases: [
+            .when(
+              state.hovered,
+              Appearance(
+                metrics: Metrics(padding: Insets.all(.term(t.radius.control))),
+              ),
+            ),
+          ],
+        ),
+      ],
+    ).validate();
+
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.styleUnknownTerm,
+        targetKind: 'term',
+        targetName: 'color.brand.fill',
+      ),
+    );
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.styleUnknownTerm,
+        targetKind: 'term',
+        targetName: 'radius.brand',
+      ),
+    );
+    expect(
+      diagnostics,
+      isNot(
+        containsDiagnostic(
+          code: DiagnosticCodes.styleUnknownTerm,
+          targetKind: 'term',
+          targetName: 'radius.control',
+        ),
+      ),
+    );
+  });
+
   test('keeps binding-level duplicate assignment diagnostics', () {
     const fill = Term<Color>(Identifier('color.action.fill'));
 

--- a/test/style/identifier_test.dart
+++ b/test/style/identifier_test.dart
@@ -23,23 +23,23 @@ void main() {
   test('reports invalid identifier formats', () {
     expect(
       const Identifier('').validate(),
-      containsDiagnosticCode(DiagnosticCodes.identifierEmpty),
+      containsDiagnostic(code: DiagnosticCodes.identifierEmpty),
     );
     expect(
       const Identifier('color..action').validate(),
-      containsDiagnosticCode(DiagnosticCodes.identifierEmptySegment),
+      containsDiagnostic(code: DiagnosticCodes.identifierEmptySegment),
     );
     expect(
       const Identifier('Color.Action').validate(),
-      containsDiagnosticCode(DiagnosticCodes.identifierInvalidSegment),
+      containsDiagnostic(code: DiagnosticCodes.identifierInvalidSegment),
     );
     expect(
       const Identifier('color action').validate(),
-      containsDiagnosticCode(DiagnosticCodes.identifierInvalidSegment),
+      containsDiagnostic(code: DiagnosticCodes.identifierInvalidSegment),
     );
     expect(
       const Identifier('color.action-fill').validate(),
-      containsDiagnosticCode(DiagnosticCodes.identifierInvalidSegment),
+      containsDiagnostic(code: DiagnosticCodes.identifierInvalidSegment),
     );
   });
 }

--- a/test/style/src/identifier_validation_test.dart
+++ b/test/style/src/identifier_validation_test.dart
@@ -14,11 +14,11 @@ void main() {
 
     expect(
       duplicateDiagnostics,
-      containsDiagnosticCode(DiagnosticCodes.identifierDuplicate),
+      containsDiagnostic(code: DiagnosticCodes.identifierDuplicate),
     );
     expect(
       duplicateDiagnostics,
-      containsDiagnosticCode(DiagnosticCodes.identifierDuplicateIgnoringCase),
+      containsDiagnostic(code: DiagnosticCodes.identifierDuplicateIgnoringCase),
     );
   });
 }


### PR DESCRIPTION
## Summary

- Add `Design<V extends Vocabulary>` as the style-system manifest with typed vocabulary, bindings, styles, and policies.
- Add `Vocabulary`, `Policy`, and `PolicyContext` for enumerable typed term trees and custom validation rules.
- Add structural validation for duplicate identifiers, missing binding values, duplicate binding assignments, and unknown contract members.
- Export the design manifest API through `package:odroe/style.dart`.

## Validation

- `dart analyze .`
- `dart test`
- `dart doc --dry-run .`
- `git diff --check`

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new style manifest system for defining design vocabularies, bindings, styles, and policies.
  * Exposed validation results so style definitions can be checked before use.

* **Bug Fixes**
  * Added validation for missing required values, duplicate identifiers, and invalid style references.
  * Improved handling of style conditions and contract checks for parts, axes, and states.

* **Tests**
  * Added broad coverage for validation behavior and policy-reported diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->