### PR TITLE
feat: add style resolution

### DIFF
--- a/lib/src/style/diagnostic.dart
+++ b/lib/src/style/diagnostic.dart
@@ -99,6 +99,30 @@ abstract final class DiagnosticCodes {
   static const identifierDuplicateIgnoringCase =
       'identifier.duplicate_ignoring_case';
 
+  /// A style property references a term the selected binding does not assign.
+  ///
+  /// Resolution reports this when the final merged appearance still contains a
+  /// [Property.term] reference, but the selected [Binding] has no assignment for
+  /// that term. Declarations remain lazy; this code appears only when a style is
+  /// resolved with a concrete binding.
+  static const resolutionUnresolvedTerm = 'resolution.unresolved_term';
+
+  /// A binding assignment cannot satisfy the type expected by a style property.
+  ///
+  /// Resolution reports this when the selected [Binding] contains the requested
+  /// term identifier but the stored value cannot be used by the term referenced
+  /// from the resolved property.
+  static const resolutionInvalidTermValueType =
+      'resolution.invalid_term_value_type';
+
+  /// A condition cannot be evaluated by the core resolver.
+  ///
+  /// Resolution reports this for custom [Condition] subclasses that are outside
+  /// the current core condition model. Platform adapters or extension packages
+  /// can evaluate their own condition types before calling the core resolver.
+  static const resolutionUnsupportedCondition =
+      'resolution.unsupported_condition';
+
   /// A style declares a part that is not present in its contract.
   ///
   /// Contract validation is owned by the style because parts are only meaningful

--- a/lib/src/style/resolution.dart
+++ b/lib/src/style/resolution.dart
@@ -300,10 +300,17 @@ final class _ResolutionState {
           return const _ConditionMatch.invalid();
         }
 
+        final hasActiveValue = _axisValues.containsKey(axis.id.value);
         final active = _axisValues[axis.id.value];
-        final activeAxis = active?.axis ?? declaredAxis ?? axis;
-        final activeValue =
-            active?.value ?? declaredAxis?.defaultValue ?? axis.defaultValue;
+        final activeAxis = hasActiveValue ? active!.axis : declaredAxis ?? axis;
+        final Object? activeValue;
+        if (hasActiveValue) {
+          activeValue = active!.value;
+        } else if (declaredAxis != null) {
+          activeValue = declaredAxis.defaultValue;
+        } else {
+          activeValue = axis.defaultValue;
+        }
         return _ConditionMatch(
           matches: axis.acceptsContract(activeAxis) && activeValue == value,
         );

--- a/lib/src/style/resolution.dart
+++ b/lib/src/style/resolution.dart
@@ -301,30 +301,34 @@ final class _ResolutionState {
         }
 
         final active = _axisValues[axis.id.value];
+        final activeAxis = active?.axis ?? declaredAxis ?? axis;
+        final activeValue =
+            active?.value ?? declaredAxis?.defaultValue ?? axis.defaultValue;
         return _ConditionMatch(
-          matches:
-              active != null &&
-              axis.acceptsContract(active.axis) &&
-              active.value == value,
+          matches: axis.acceptsContract(activeAxis) && activeValue == value,
         );
       case AllCondition(:final conditions):
+        var isValid = true;
+        var matched = true;
         for (final condition in conditions) {
           final result = _matches(condition);
-          if (!result.isValid || !result.matches) {
-            return result;
-          }
+          isValid = isValid && result.isValid;
+          matched = matched && result.matches;
         }
-        return const _ConditionMatch(matches: true);
+        return isValid
+            ? _ConditionMatch(matches: matched)
+            : const _ConditionMatch.invalid();
       case AnyCondition(:final conditions):
+        var isValid = true;
         var matched = false;
         for (final condition in conditions) {
           final result = _matches(condition);
-          if (!result.isValid) {
-            return result;
-          }
+          isValid = isValid && result.isValid;
           matched = matched || result.matches;
         }
-        return _ConditionMatch(matches: matched);
+        return isValid
+            ? _ConditionMatch(matches: matched)
+            : const _ConditionMatch.invalid();
       case NotCondition(:final condition):
         final result = _matches(condition);
         return result.isValid

--- a/lib/src/style/resolution.dart
+++ b/lib/src/style/resolution.dart
@@ -1,0 +1,471 @@
+import 'appearance.dart';
+import 'axis.dart';
+import 'binding.dart';
+import 'color.dart';
+import 'condition.dart';
+import 'contract.dart';
+import 'diagnostic.dart';
+import 'dimension.dart';
+import 'identifier.dart';
+import 'state.dart';
+import 'style.dart';
+
+/// The result of resolving a [Style] against one binding and condition set.
+///
+/// Resolution stays inside the Odroe core model. The [appearance] contains
+/// concrete style values, not CSS declarations, Flutter widgets, Material theme
+/// objects, DOM nodes, or platform adapter output.
+///
+/// Diagnostics describe resolution-time problems such as a term that the
+/// selected binding does not provide. They do not throw, so tools can show a
+/// partial resolved value alongside every issue found in one pass.
+final class StyleResolution {
+  /// Creates a style resolution result.
+  StyleResolution({
+    required this.appearance,
+    Iterable<Diagnostic> diagnostics = const [],
+  }) : diagnostics = List.unmodifiable(diagnostics);
+
+  /// The resolved platform-neutral appearance.
+  final ResolvedAppearance appearance;
+
+  /// Resolution diagnostics collected while producing [appearance].
+  final List<Diagnostic> diagnostics;
+
+  /// Whether resolution completed without diagnostics.
+  bool get isValid => diagnostics.isEmpty;
+}
+
+/// A resolved platform-neutral appearance.
+///
+/// This is the concrete counterpart to [Appearance]. Term-backed properties
+/// have been looked up through a selected [Binding], and literal properties have
+/// been unwrapped into direct Dart values.
+final class ResolvedAppearance {
+  /// Creates a resolved appearance from optional visual facets.
+  const ResolvedAppearance({this.surface, this.content, this.metrics});
+
+  /// Resolved surface-facing visual values.
+  final ResolvedSurface? surface;
+
+  /// Resolved content-facing visual values.
+  final ResolvedContent? content;
+
+  /// Resolved size and spacing values.
+  final ResolvedMetrics? metrics;
+}
+
+/// Resolved surface-facing visual values.
+final class ResolvedSurface {
+  /// Creates a resolved surface declaration.
+  const ResolvedSurface({this.fill, this.stroke, this.radius, this.elevation});
+
+  /// The resolved surface fill color.
+  final Color? fill;
+
+  /// The resolved stroke or border color.
+  final Color? stroke;
+
+  /// The resolved corner or shape radius.
+  final Dimension? radius;
+
+  /// The resolved platform-neutral elevation amount or role.
+  final Dimension? elevation;
+}
+
+/// Resolved content-facing visual values.
+final class ResolvedContent {
+  /// Creates a resolved content declaration.
+  const ResolvedContent({this.color, this.text, this.icon, this.opacity});
+
+  /// The resolved foreground color.
+  final Color? color;
+
+  /// The resolved semantic text role.
+  final Identifier? text;
+
+  /// The resolved semantic icon role.
+  final Identifier? icon;
+
+  /// The resolved content opacity.
+  final double? opacity;
+}
+
+/// Resolved platform-neutral spacing and size values.
+final class ResolvedMetrics {
+  /// Creates a resolved metrics declaration.
+  const ResolvedMetrics({
+    this.padding,
+    this.gap,
+    this.width,
+    this.height,
+    this.minWidth,
+    this.minHeight,
+    this.maxWidth,
+    this.maxHeight,
+  });
+
+  /// The resolved content padding.
+  final ResolvedInsets? padding;
+
+  /// The resolved space between repeated children.
+  final Dimension? gap;
+
+  /// The resolved preferred width.
+  final Dimension? width;
+
+  /// The resolved preferred height.
+  final Dimension? height;
+
+  /// The resolved minimum width.
+  final Dimension? minWidth;
+
+  /// The resolved minimum height.
+  final Dimension? minHeight;
+
+  /// The resolved maximum width.
+  final Dimension? maxWidth;
+
+  /// The resolved maximum height.
+  final Dimension? maxHeight;
+}
+
+/// Resolved four-sided spacing.
+final class ResolvedInsets {
+  /// Creates resolved insets from explicit sides.
+  const ResolvedInsets({this.top, this.right, this.bottom, this.left});
+
+  /// The resolved top inset.
+  final Dimension? top;
+
+  /// The resolved right inset.
+  final Dimension? right;
+
+  /// The resolved bottom inset.
+  final Dimension? bottom;
+
+  /// The resolved left inset.
+  final Dimension? left;
+}
+
+/// Resolves a [Style] into concrete core values.
+extension StyleResolver<P> on Style<P> {
+  /// Resolves this style with [binding] and the active style inputs.
+  ///
+  /// Merge order is fixed and deterministic:
+  ///
+  /// * root appearance;
+  /// * selected [part] appearance, when present;
+  /// * matching cases in declaration order;
+  /// * [instanceOverride], when provided.
+  ///
+  /// Terms are resolved only after the final appearance has been merged. This
+  /// means a later literal override can replace an earlier term reference
+  /// without requiring that earlier term to exist in the selected binding.
+  ///
+  /// ```dart
+  /// final resolved = button.resolve(
+  ///   binding: light,
+  ///   part: ButtonPart.icon,
+  ///   states: [state.hovered],
+  ///   axisValues: [tone(ButtonTone.danger)],
+  /// );
+  /// ```
+  StyleResolution resolve({
+    required Binding binding,
+    P? part,
+    Iterable<State> states = const [],
+    Iterable<AxisCondition<Object?>> axisValues = const [],
+    Appearance? instanceOverride,
+  }) {
+    final state = _ResolutionState(
+      binding: binding,
+      contract: contract,
+      states: states,
+      axisValues: axisValues,
+      styleId: id,
+    );
+    var appearance = root;
+
+    if (part != null) {
+      if (contract != null && !contract!.allowsPart(part)) {
+        state.report(
+          Diagnostic(
+            code: DiagnosticCodes.styleUnknownPart,
+            target: DiagnosticTarget(kind: 'style', name: id.value),
+            message:
+                'Style `${id.value}` resolves part `$part`, but that part is '
+                'not present in its contract.',
+          ),
+        );
+      }
+
+      final partAppearance = parts[part];
+      if (partAppearance != null) {
+        appearance = appearance.merge(partAppearance);
+      }
+    }
+
+    for (final styleCase in cases) {
+      if (state.matches(styleCase.when)) {
+        appearance = appearance.merge(styleCase.appearance);
+      }
+    }
+
+    if (instanceOverride != null) {
+      appearance = appearance.merge(instanceOverride);
+    }
+
+    return StyleResolution(
+      appearance: state.resolveAppearance(appearance),
+      diagnostics: state.diagnostics,
+    );
+  }
+}
+
+final class _ResolutionState {
+  _ResolutionState({
+    required Binding binding,
+    required this.contract,
+    required Iterable<State> states,
+    required Iterable<AxisCondition<Object?>> axisValues,
+    required this.styleId,
+  }) : _states = Set.unmodifiable(states),
+       _axisValues = Map.unmodifiable({
+         for (final value in axisValues) value.axis.id.value: value,
+       }),
+       _assignments = _assignmentsById(binding.assignments);
+
+  final Contract<Object?>? contract;
+  final Set<State> _states;
+  final Map<String, AxisCondition<Object?>> _axisValues;
+  final Map<String, Assignment<Object?>> _assignments;
+  final Identifier styleId;
+  final List<Diagnostic> diagnostics = [];
+
+  void report(Diagnostic diagnostic) {
+    diagnostics.add(diagnostic);
+  }
+
+  bool matches(Condition condition) {
+    final result = _matches(condition);
+    return result.isValid && result.matches;
+  }
+
+  _ConditionMatch _matches(Condition condition) {
+    switch (condition) {
+      case State(:final id):
+        if (contract != null && !contract!.allowsState(condition)) {
+          report(
+            Diagnostic(
+              code: DiagnosticCodes.styleUnknownState,
+              target: DiagnosticTarget(kind: 'style', name: styleId.value),
+              message:
+                  'Style `${styleId.value}` uses state `${id.value}` that is '
+                  'not present in its contract.',
+            ),
+          );
+          return const _ConditionMatch.invalid();
+        }
+
+        return _ConditionMatch(matches: _states.contains(condition));
+      case AxisCondition<Object?>(:final axis, :final value):
+        final declaredAxis = contract?.axisNamed(axis.id);
+        if (contract != null && declaredAxis == null) {
+          report(
+            Diagnostic(
+              code: DiagnosticCodes.styleUnknownAxis,
+              target: DiagnosticTarget(kind: 'style', name: styleId.value),
+              message:
+                  'Style `${styleId.value}` uses axis `${axis.id.value}` that '
+                  'is not present in its contract.',
+            ),
+          );
+          return const _ConditionMatch.invalid();
+        }
+
+        if (declaredAxis != null &&
+            (!declaredAxis.acceptsContract(axis) ||
+                !declaredAxis.acceptsValue(value))) {
+          report(
+            Diagnostic(
+              code: DiagnosticCodes.styleInvalidAxisValueType,
+              target: DiagnosticTarget(kind: 'axis', name: axis.id.value),
+              message:
+                  'Style `${styleId.value}` uses a ${value.runtimeType} value '
+                  'for axis `${axis.id.value}`, but its contract declares that '
+                  'axis as ${declaredAxis.valueType}.',
+            ),
+          );
+          return const _ConditionMatch.invalid();
+        }
+
+        final active = _axisValues[axis.id.value];
+        return _ConditionMatch(
+          matches:
+              active != null &&
+              axis.acceptsContract(active.axis) &&
+              active.value == value,
+        );
+      case AllCondition(:final conditions):
+        for (final condition in conditions) {
+          final result = _matches(condition);
+          if (!result.isValid || !result.matches) {
+            return result;
+          }
+        }
+        return const _ConditionMatch(matches: true);
+      case AnyCondition(:final conditions):
+        var matched = false;
+        for (final condition in conditions) {
+          final result = _matches(condition);
+          if (!result.isValid) {
+            return result;
+          }
+          matched = matched || result.matches;
+        }
+        return _ConditionMatch(matches: matched);
+      case NotCondition(:final condition):
+        final result = _matches(condition);
+        return result.isValid
+            ? _ConditionMatch(matches: !result.matches)
+            : result;
+      case Condition():
+        report(
+          Diagnostic(
+            code: DiagnosticCodes.resolutionUnsupportedCondition,
+            target: DiagnosticTarget(kind: 'condition'),
+            message:
+                'Style `${styleId.value}` uses an unsupported condition type '
+                '`${condition.runtimeType}`.',
+          ),
+        );
+        return const _ConditionMatch.invalid();
+    }
+  }
+
+  ResolvedAppearance resolveAppearance(Appearance appearance) {
+    return ResolvedAppearance(
+      surface: resolveSurface(appearance.surface),
+      content: resolveContent(appearance.content),
+      metrics: resolveMetrics(appearance.metrics),
+    );
+  }
+
+  ResolvedSurface? resolveSurface(Surface? surface) {
+    if (surface == null) {
+      return null;
+    }
+
+    return ResolvedSurface(
+      fill: resolveProperty(surface.fill),
+      stroke: resolveProperty(surface.stroke),
+      radius: resolveProperty(surface.radius),
+      elevation: resolveProperty(surface.elevation),
+    );
+  }
+
+  ResolvedContent? resolveContent(Content? content) {
+    if (content == null) {
+      return null;
+    }
+
+    return ResolvedContent(
+      color: resolveProperty(content.color),
+      text: resolveProperty(content.text),
+      icon: resolveProperty(content.icon),
+      opacity: resolveProperty(content.opacity),
+    );
+  }
+
+  ResolvedMetrics? resolveMetrics(Metrics? metrics) {
+    if (metrics == null) {
+      return null;
+    }
+
+    return ResolvedMetrics(
+      padding: resolveInsets(metrics.padding),
+      gap: resolveProperty(metrics.gap),
+      width: resolveProperty(metrics.width),
+      height: resolveProperty(metrics.height),
+      minWidth: resolveProperty(metrics.minWidth),
+      minHeight: resolveProperty(metrics.minHeight),
+      maxWidth: resolveProperty(metrics.maxWidth),
+      maxHeight: resolveProperty(metrics.maxHeight),
+    );
+  }
+
+  ResolvedInsets? resolveInsets(Insets? insets) {
+    if (insets == null) {
+      return null;
+    }
+
+    return ResolvedInsets(
+      top: resolveProperty(insets.top),
+      right: resolveProperty(insets.right),
+      bottom: resolveProperty(insets.bottom),
+      left: resolveProperty(insets.left),
+    );
+  }
+
+  T? resolveProperty<T>(Property<T>? property) {
+    switch (property) {
+      case null:
+        return null;
+      case LiteralProperty<T>(:final value):
+        return value;
+      case TermProperty<T>(:final term):
+        final termId = term.id.value;
+        final assignment = _assignments[termId];
+        if (assignment == null) {
+          report(
+            Diagnostic(
+              code: DiagnosticCodes.resolutionUnresolvedTerm,
+              target: DiagnosticTarget(kind: 'term', name: termId),
+              message:
+                  'Style `${styleId.value}` references term `$termId`, but '
+                  'binding does not assign it.',
+            ),
+          );
+          return null;
+        }
+
+        if (!term.acceptsValue(assignment.value)) {
+          report(
+            Diagnostic(
+              code: DiagnosticCodes.resolutionInvalidTermValueType,
+              target: DiagnosticTarget(kind: 'term', name: termId),
+              message:
+                  'Style `${styleId.value}` resolves term `$termId` from a '
+                  '${assignment.value.runtimeType} value, but the property '
+                  'expects ${term.valueType}.',
+            ),
+          );
+          return null;
+        }
+
+        return assignment.value as T;
+    }
+  }
+}
+
+final class _ConditionMatch {
+  const _ConditionMatch({required this.matches}) : isValid = true;
+
+  const _ConditionMatch.invalid() : matches = false, isValid = false;
+
+  final bool matches;
+  final bool isValid;
+}
+
+Map<String, Assignment<Object?>> _assignmentsById(
+  Iterable<Assignment<Object?>> assignments,
+) {
+  final assignmentsById = <String, Assignment<Object?>>{};
+
+  for (final assignment in assignments) {
+    assignmentsById.putIfAbsent(assignment.term.id.value, () => assignment);
+  }
+
+  return assignmentsById;
+}

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -33,6 +33,7 @@ export 'src/style/design.dart';
 export 'src/style/diagnostic.dart';
 export 'src/style/dimension.dart';
 export 'src/style/identifier.dart';
+export 'src/style/resolution.dart';
 export 'src/style/state.dart';
 export 'src/style/style.dart';
 export 'src/style/value_contract.dart';

--- a/test/style/resolution_test.dart
+++ b/test/style/resolution_test.dart
@@ -1,0 +1,271 @@
+import 'package:odroe/style.dart';
+import 'package:test/test.dart';
+
+import '_utils.dart';
+
+enum ButtonPart { icon, label }
+
+enum ButtonSize { sm, md }
+
+enum ButtonTone { primary, danger }
+
+void main() {
+  test('resolves term-backed properties through the selected binding', () {
+    const fill = Term<Color>(Identifier('color.action.fill'));
+    const radius = Term<Dimension>(Identifier('radius.control'));
+    final binding = Binding(Identifier('light'), [
+      fill(const Color(0xff006adc)),
+      radius(8.px),
+    ]);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(
+        surface: Surface(fill: .term(fill), radius: .term(radius)),
+      ),
+    );
+
+    final resolution = style.resolve(binding: binding);
+
+    expect(resolution.isValid, isTrue);
+    expect(resolution.appearance.surface?.fill, const Color(0xff006adc));
+    expect(resolution.appearance.surface?.radius, 8.px);
+  });
+
+  test('merges root part matching cases and instance override in order', () {
+    const fill = Term<Color>(Identifier('color.action.fill'));
+    const hoverFill = Term<Color>(Identifier('color.action.fillHover'));
+    const dangerFill = Term<Color>(Identifier('color.danger.fill'));
+    const tone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    final binding = Binding(Identifier('light'), [
+      fill(const Color(0xff006adc)),
+      hoverFill(const Color(0xff0055aa)),
+      dangerFill(const Color(0xffc62828)),
+    ]);
+    final style = Style<ButtonPart>(
+      id: Identifier('button'),
+      root: const Appearance(
+        surface: Surface(fill: .term(fill), radius: .literal(Dimension.px(8))),
+      ),
+      parts: const {
+        ButtonPart.icon: Appearance(
+          surface: Surface(radius: .literal(Dimension.px(4))),
+        ),
+      },
+      cases: [
+        .when(
+          state.hovered,
+          const Appearance(surface: Surface(fill: .term(hoverFill))),
+        ),
+        .when(
+          tone(.danger),
+          const Appearance(surface: Surface(fill: .term(dangerFill))),
+        ),
+      ],
+    );
+
+    final resolution = style.resolve(
+      binding: binding,
+      part: ButtonPart.icon,
+      states: [state.hovered],
+      axisValues: [tone(.danger)],
+      instanceOverride: const Appearance(
+        surface: Surface(fill: .literal(Color(0xff111111))),
+      ),
+    );
+
+    expect(resolution.diagnostics, isEmpty);
+    expect(resolution.appearance.surface?.fill, const Color(0xff111111));
+    expect(resolution.appearance.surface?.radius, 4.px);
+  });
+
+  test('applies matching cases in declaration order', () {
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(content: Content(opacity: .literal(1))),
+      cases: [
+        .when(
+          state.hovered,
+          const Appearance(content: Content(opacity: .literal(0.8))),
+        ),
+        .when(
+          state.hovered,
+          const Appearance(content: Content(opacity: .literal(0.6))),
+        ),
+      ],
+    );
+
+    final resolution = style.resolve(binding: binding, states: [state.hovered]);
+
+    expect(resolution.diagnostics, isEmpty);
+    expect(resolution.appearance.content?.opacity, 0.6);
+  });
+
+  test('matches compound all any and not conditions', () {
+    const tone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    const size = Axis<ButtonSize>(
+      id: Identifier('button.size'),
+      defaultValue: ButtonSize.md,
+    );
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(content: Content(opacity: .literal(1))),
+      cases: [
+        .all([
+          tone(.danger),
+          size(.sm),
+        ], const Appearance(content: Content(opacity: .literal(0.7)))),
+        .any([
+          state.pressed,
+          state.focusVisible,
+        ], const Appearance(content: Content(opacity: .literal(0.6)))),
+        .when(
+          Condition.not(state.disabled),
+          const Appearance(content: Content(opacity: .literal(0.5))),
+        ),
+      ],
+    );
+
+    final resolution = style.resolve(
+      binding: binding,
+      states: [state.focusVisible],
+      axisValues: [tone(.danger), size(.sm)],
+    );
+
+    expect(resolution.diagnostics, isEmpty);
+    expect(resolution.appearance.content?.opacity, 0.5);
+  });
+
+  test('reports unresolved terms in the final merged appearance', () {
+    const fill = Term<Color>(Identifier('color.action.fill'));
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(surface: Surface(fill: .term(fill))),
+    );
+
+    final resolution = style.resolve(binding: binding);
+
+    expect(
+      resolution.diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.resolutionUnresolvedTerm,
+        targetKind: 'term',
+        targetName: 'color.action.fill',
+      ),
+    );
+    expect(resolution.appearance.surface?.fill, isNull);
+  });
+
+  test('does not resolve overwritten term references', () {
+    const fill = Term<Color>(Identifier('color.action.fill'));
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(surface: Surface(fill: .term(fill))),
+    );
+
+    final resolution = style.resolve(
+      binding: binding,
+      instanceOverride: const Appearance(
+        surface: Surface(fill: .literal(Color(0xff111111))),
+      ),
+    );
+
+    expect(resolution.diagnostics, isEmpty);
+    expect(resolution.appearance.surface?.fill, const Color(0xff111111));
+  });
+
+  test('reports incompatible binding values while resolving terms', () {
+    const fill = Term<Color>(Identifier('color.action.fill'));
+    const wrongFill = Term<Dimension>(Identifier('color.action.fill'));
+    final binding = Binding(Identifier('light'), [wrongFill(8.px)]);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(surface: Surface(fill: .term(fill))),
+    );
+
+    final resolution = style.resolve(binding: binding);
+
+    expect(
+      resolution.diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.resolutionInvalidTermValueType,
+        targetKind: 'term',
+        targetName: 'color.action.fill',
+      ),
+    );
+  });
+
+  test('reports contract violations while matching conditions and parts', () {
+    const tone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    const size = Axis<ButtonSize>(
+      id: Identifier('button.size'),
+      defaultValue: ButtonSize.md,
+    );
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<ButtonPart>(
+      id: Identifier('button'),
+      contract: Contract<ButtonPart>(
+        parts: {ButtonPart.icon},
+        axes: [tone],
+        states: {state.hovered},
+      ),
+      root: const Appearance(),
+      cases: [
+        .when(size(.sm), const Appearance()),
+        .when(state.disabled, const Appearance()),
+      ],
+    );
+
+    final resolution = style.resolve(
+      binding: binding,
+      part: ButtonPart.label,
+      states: [state.disabled],
+      axisValues: [size(.sm)],
+    );
+
+    expect(
+      resolution.diagnostics,
+      containsDiagnostic(code: DiagnosticCodes.styleUnknownPart),
+    );
+    expect(
+      resolution.diagnostics,
+      containsDiagnostic(code: DiagnosticCodes.styleUnknownAxis),
+    );
+    expect(
+      resolution.diagnostics,
+      containsDiagnostic(code: DiagnosticCodes.styleUnknownState),
+    );
+  });
+
+  test('reports unsupported condition types', () {
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(),
+      cases: [.when(const _UnsupportedCondition(), const Appearance())],
+    );
+
+    final resolution = style.resolve(binding: binding);
+
+    expect(
+      resolution.diagnostics,
+      containsDiagnostic(code: DiagnosticCodes.resolutionUnsupportedCondition),
+    );
+  });
+}
+
+final class _UnsupportedCondition extends Condition {
+  const _UnsupportedCondition();
+}

--- a/test/style/resolution_test.dart
+++ b/test/style/resolution_test.dart
@@ -166,6 +166,68 @@ void main() {
     expect(resolution.appearance.content?.opacity, 0.75);
   });
 
+  test('preserves explicit null axis values', () {
+    const tone = Axis<ButtonTone?>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(content: Content(opacity: .literal(1))),
+      cases: [
+        .when(
+          tone(null),
+          const Appearance(content: Content(opacity: .literal(0.5))),
+        ),
+        .when(
+          tone(.primary),
+          const Appearance(content: Content(opacity: .literal(0.75))),
+        ),
+      ],
+    );
+
+    final resolution = style.resolve(
+      binding: binding,
+      axisValues: [tone(null)],
+    );
+
+    expect(resolution.diagnostics, isEmpty);
+    expect(resolution.appearance.content?.opacity, 0.5);
+  });
+
+  test('uses nullable contract axis defaults', () {
+    const declaredTone = Axis<ButtonTone?>(
+      id: Identifier('button.tone'),
+      defaultValue: null,
+    );
+    const authoredTone = Axis<ButtonTone?>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<void>(
+      id: Identifier('button'),
+      contract: Contract(axes: [declaredTone]),
+      root: const Appearance(content: Content(opacity: .literal(1))),
+      cases: [
+        .when(
+          authoredTone(null),
+          const Appearance(content: Content(opacity: .literal(0.5))),
+        ),
+        .when(
+          authoredTone(.primary),
+          const Appearance(content: Content(opacity: .literal(0.75))),
+        ),
+      ],
+    );
+
+    final resolution = style.resolve(binding: binding);
+
+    expect(resolution.diagnostics, isEmpty);
+    expect(resolution.appearance.content?.opacity, 0.5);
+  });
+
   test('collects diagnostics from every compound condition child', () {
     final binding = Binding(Identifier('light'), const []);
     final style = Style<void>(

--- a/test/style/resolution_test.dart
+++ b/test/style/resolution_test.dart
@@ -143,6 +143,55 @@ void main() {
     expect(resolution.appearance.content?.opacity, 0.5);
   });
 
+  test('uses axis default values when no active value is supplied', () {
+    const tone = Axis<ButtonTone>(
+      id: Identifier('button.tone'),
+      defaultValue: ButtonTone.primary,
+    );
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(content: Content(opacity: .literal(1))),
+      cases: [
+        .when(
+          tone(.primary),
+          const Appearance(content: Content(opacity: .literal(0.75))),
+        ),
+      ],
+    );
+
+    final resolution = style.resolve(binding: binding);
+
+    expect(resolution.diagnostics, isEmpty);
+    expect(resolution.appearance.content?.opacity, 0.75);
+  });
+
+  test('collects diagnostics from every compound condition child', () {
+    final binding = Binding(Identifier('light'), const []);
+    final style = Style<void>(
+      id: Identifier('button'),
+      root: const Appearance(),
+      cases: [
+        .all(const [
+          _UnsupportedCondition(),
+          _UnsupportedCondition(),
+        ], const Appearance()),
+        .any(const [
+          _UnsupportedCondition(),
+          _UnsupportedCondition(),
+        ], const Appearance()),
+      ],
+    );
+
+    final resolution = style.resolve(binding: binding);
+    final unsupportedDiagnostics = resolution.diagnostics.where(
+      (diagnostic) =>
+          diagnostic.code == DiagnosticCodes.resolutionUnsupportedCondition,
+    );
+
+    expect(unsupportedDiagnostics, hasLength(4));
+  });
+
   test('reports unresolved terms in the final merged appearance', () {
     const fill = Term<Color>(Identifier('color.action.fill'));
     final binding = Binding(Identifier('light'), const []);


### PR DESCRIPTION
## Summary

- add a platform-neutral `Style.resolve(...)` entrypoint
- resolve final merged appearances into concrete Odroe core values
- support root -> part -> matching cases -> instance override merge order
- report resolution diagnostics for unresolved terms, invalid term values, unsupported conditions, and contract violations

## Validation

- `dart analyze .`
- `dart test`
- `dart doc --dry-run .`
- `git diff --check`

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added style resolution support that produces concrete, platform-neutral appearance values.
  * Exposed resolved appearance data for surface, content, and metrics properties.
  * Made the new resolution API available from the main style export.

* **Bug Fixes**
  * Added diagnostics for unresolved terms, invalid term value types, and unsupported conditions.
  * Improved handling of layered appearances, including case order, state/axis matching, and instance overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->