### PR TITLE
feat: add structured surface stroke and shadow

### DIFF
--- a/example/style_primitives.dart
+++ b/example/style_primitives.dart
@@ -27,6 +27,26 @@ const surfaceRole = Axis<SurfaceRole>(
 
 const terms = AppTerms();
 
+final noShadow = Shadow([]);
+
+final raisedShadow = Shadow([
+  const ShadowLayer(
+    color: Color(0x1f000000),
+    offsetX: Dimension.px(0),
+    offsetY: Dimension.px(2),
+    blur: Dimension.px(8),
+  ),
+]);
+
+final overlayShadow = Shadow([
+  const ShadowLayer(
+    color: Color(0x29000000),
+    offsetX: Dimension.px(0),
+    offsetY: Dimension.px(8),
+    blur: Dimension.px(24),
+  ),
+]);
+
 final light = Binding(Identifier('light'), [
   terms.color.surface.canvas(const Color(0xffffffff)),
   terms.color.surface.raised(const Color(0xfff8f8f8)),
@@ -65,15 +85,18 @@ final light = Binding(Identifier('light'), [
   terms.radius.control(8.px),
   terms.radius.surface(12.px),
   terms.radius.field(6.px),
+  terms.stroke.width(1.px),
+  terms.stroke.focusWidth(2.px),
+  terms.stroke.style(StrokeStyle.solid),
   terms.size.icon(18.px),
   terms.size.iconSm(16.px),
   terms.size.controlHeight(40.px),
   terms.size.controlSmHeight(32.px),
   terms.size.fieldHeight(40.px),
   terms.size.cardMinWidth(280.px),
-  terms.elevation.none(0.px),
-  terms.elevation.raised(2.px),
-  terms.elevation.overlay(8.px),
+  terms.shadow.none(noShadow),
+  terms.shadow.raised(raisedShadow),
+  terms.shadow.overlay(overlayShadow),
   terms.opacity.disabled(0.48),
   terms.type.buttonLabel(const Identifier('text.buttonLabel')),
   terms.type.buttonLabelSm(const Identifier('text.buttonLabelSm')),
@@ -125,15 +148,18 @@ final dark = Binding(Identifier('dark'), [
   terms.radius.control(8.px),
   terms.radius.surface(12.px),
   terms.radius.field(6.px),
+  terms.stroke.width(1.px),
+  terms.stroke.focusWidth(2.px),
+  terms.stroke.style(StrokeStyle.solid),
   terms.size.icon(18.px),
   terms.size.iconSm(16.px),
   terms.size.controlHeight(40.px),
   terms.size.controlSmHeight(32.px),
   terms.size.fieldHeight(40.px),
   terms.size.cardMinWidth(280.px),
-  terms.elevation.none(0.px),
-  terms.elevation.raised(2.px),
-  terms.elevation.overlay(8.px),
+  terms.shadow.none(noShadow),
+  terms.shadow.raised(raisedShadow),
+  terms.shadow.overlay(overlayShadow),
   terms.opacity.disabled(0.52),
   terms.type.buttonLabel(const Identifier('text.buttonLabel')),
   terms.type.buttonLabelSm(const Identifier('text.buttonLabelSm')),
@@ -217,7 +243,15 @@ final button = Style<ButtonPart>(
     ], Appearance(surface: Surface(fill: .term(terms.color.danger.fillHover)))),
     .when(
       state.focusVisible,
-      Appearance(surface: Surface(stroke: .term(terms.color.focus.ring))),
+      Appearance(
+        surface: Surface(
+          stroke: Stroke(
+            color: .term(terms.color.focus.ring),
+            width: .term(terms.stroke.focusWidth),
+            style: .term(terms.stroke.style),
+          ),
+        ),
+      ),
     ),
     .when(
       state.disabled,
@@ -236,9 +270,13 @@ final card = Style<CardPart>(
   root: Appearance(
     surface: Surface(
       fill: .term(terms.color.surface.raised),
-      stroke: .term(terms.color.surface.stroke),
+      stroke: Stroke(
+        color: .term(terms.color.surface.stroke),
+        width: .term(terms.stroke.width),
+        style: .term(terms.stroke.style),
+      ),
       radius: .term(terms.radius.surface),
-      elevation: .term(terms.elevation.raised),
+      shadow: .term(terms.shadow.raised),
     ),
     content: Content(color: .term(terms.color.content.primary)),
     metrics: Metrics(
@@ -266,7 +304,7 @@ final card = Style<CardPart>(
       Appearance(
         surface: Surface(
           fill: .term(terms.color.surface.canvas),
-          elevation: .term(terms.elevation.none),
+          shadow: .term(terms.shadow.none),
         ),
       ),
     ),
@@ -275,20 +313,24 @@ final card = Style<CardPart>(
       Appearance(
         surface: Surface(
           fill: .term(terms.color.surface.overlay),
-          stroke: .term(terms.color.surface.strokeStrong),
-          elevation: .term(terms.elevation.overlay),
+          stroke: Stroke(color: .term(terms.color.surface.strokeStrong)),
+          shadow: .term(terms.shadow.overlay),
         ),
       ),
     ),
     .when(
       state.hovered,
       Appearance(
-        surface: Surface(stroke: .term(terms.color.surface.strokeStrong)),
+        surface: Surface(
+          stroke: Stroke(color: .term(terms.color.surface.strokeStrong)),
+        ),
       ),
     ),
     .when(
       state.focusVisible,
-      Appearance(surface: Surface(stroke: .term(terms.color.focus.ring))),
+      Appearance(
+        surface: Surface(stroke: Stroke(color: .term(terms.color.focus.ring))),
+      ),
     ),
   ],
 );
@@ -308,7 +350,11 @@ final textField = Style<TextFieldPart>(
   root: Appearance(
     surface: Surface(
       fill: .term(terms.color.field.fill),
-      stroke: .term(terms.color.field.border),
+      stroke: Stroke(
+        color: .term(terms.color.field.border),
+        width: .term(terms.stroke.width),
+        style: .term(terms.stroke.style),
+      ),
       radius: .term(terms.radius.field),
     ),
     content: Content(color: .term(terms.color.content.primary)),
@@ -358,17 +404,23 @@ final textField = Style<TextFieldPart>(
     .when(
       state.focused,
       Appearance(
-        surface: Surface(stroke: .term(terms.color.field.borderFocus)),
+        surface: Surface(
+          stroke: Stroke(color: .term(terms.color.field.borderFocus)),
+        ),
       ),
     ),
     .when(
       state.focusVisible,
-      Appearance(surface: Surface(stroke: .term(terms.color.focus.ring))),
+      Appearance(
+        surface: Surface(stroke: Stroke(color: .term(terms.color.focus.ring))),
+      ),
     ),
     .when(
       state.error,
       Appearance(
-        surface: Surface(stroke: .term(terms.color.field.borderError)),
+        surface: Surface(
+          stroke: Stroke(color: .term(terms.color.field.borderError)),
+        ),
         content: Content(color: .term(terms.color.danger.stroke)),
       ),
     ),
@@ -447,9 +499,11 @@ final class AppTerms implements Vocabulary {
 
   RadiusTerms get radius => const RadiusTerms();
 
+  StrokeTerms get stroke => const StrokeTerms();
+
   SizeTerms get size => const SizeTerms();
 
-  ElevationTerms get elevation => const ElevationTerms();
+  ShadowTerms get shadow => const ShadowTerms();
 
   OpacityTerms get opacity => const OpacityTerms();
 
@@ -462,8 +516,9 @@ final class AppTerms implements Vocabulary {
     ...color.terms,
     ...space.terms,
     ...radius.terms,
+    ...stroke.terms,
     ...size.terms,
-    ...elevation.terms,
+    ...shadow.terms,
     ...opacity.terms,
     ...type.terms,
     ...icon.terms,
@@ -681,14 +736,27 @@ final class SizeTerms implements Vocabulary {
   ];
 }
 
-final class ElevationTerms implements Vocabulary {
-  const ElevationTerms();
+final class StrokeTerms implements Vocabulary {
+  const StrokeTerms();
 
-  Term<Dimension> get none => const Term(Identifier('elevation.none'));
+  Term<Dimension> get width => const Term(Identifier('stroke.width'));
 
-  Term<Dimension> get raised => const Term(Identifier('elevation.raised'));
+  Term<Dimension> get focusWidth => const Term(Identifier('stroke.focusWidth'));
 
-  Term<Dimension> get overlay => const Term(Identifier('elevation.overlay'));
+  Term<StrokeStyle> get style => const Term(Identifier('stroke.style'));
+
+  @override
+  Iterable<Term> get terms => [width, focusWidth, style];
+}
+
+final class ShadowTerms implements Vocabulary {
+  const ShadowTerms();
+
+  Term<Shadow> get none => const Term(Identifier('shadow.none'));
+
+  Term<Shadow> get raised => const Term(Identifier('shadow.raised'));
+
+  Term<Shadow> get overlay => const Term(Identifier('shadow.overlay'));
 
   @override
   Iterable<Term> get terms => [none, raised, overlay];
@@ -767,7 +835,13 @@ void main() {
   );
 
   print('button.fill=${formatColor(resolved.appearance.surface?.fill)}');
-  print('button.stroke=${formatColor(resolved.appearance.surface?.stroke)}');
+  print(
+    'button.stroke=${formatColor(resolved.appearance.surface?.stroke?.color)}',
+  );
+  print(
+    'button.strokeWidth='
+    '${formatDimension(resolved.appearance.surface?.stroke?.width)}',
+  );
   print('button.content=${formatColor(resolved.appearance.content?.color)}');
   print('button.icon=${resolved.appearance.content?.icon?.value}');
   print('button.label=${resolved.appearance.content?.text?.value}');

--- a/lib/src/style/appearance.dart
+++ b/lib/src/style/appearance.dart
@@ -62,34 +62,143 @@ final class Appearance implements Mergeable<Appearance> {
 /// The visual treatment of a surface.
 ///
 /// Surface properties describe the container plane: its fill, outline, radius,
-/// and elevation. They deliberately avoid CSS boxes, Flutter decorations, and
+/// and shadow. They deliberately avoid CSS boxes, Flutter decorations, and
 /// Material components.
 final class Surface implements Mergeable<Surface> {
   /// Creates a partial surface declaration.
-  const Surface({this.fill, this.stroke, this.radius, this.elevation});
+  const Surface({this.fill, this.stroke, this.radius, this.shadow});
 
   /// The surface fill color.
   final Property<Color>? fill;
 
-  /// The stroke or border color for the surface.
-  final Property<Color>? stroke;
+  /// The stroke or border treatment for the surface.
+  final Stroke? stroke;
 
   /// The corner radius or shape radius for the surface.
   final Property<Dimension>? radius;
 
-  /// The platform-neutral elevation role or amount.
-  final Property<Dimension>? elevation;
+  /// The shadow cast by the surface.
+  final Property<Shadow>? shadow;
 
   /// Returns this surface with non-null properties from [later] applied.
   @override
   Surface merge(Surface later) {
     return Surface(
       fill: later.fill ?? fill,
-      stroke: later.stroke ?? stroke,
+      stroke: stroke.mergedWith(later.stroke),
       radius: later.radius ?? radius,
-      elevation: later.elevation ?? elevation,
+      shadow: later.shadow ?? shadow,
     );
   }
+}
+
+/// The outline treatment of a surface.
+///
+/// Stroke keeps border-like properties together so a later appearance can
+/// override only the color without losing the previously declared width or
+/// style. CSS adapters can project this to border properties, while Flutter
+/// adapters can project it to `BorderSide`.
+final class Stroke implements Mergeable<Stroke> {
+  /// Creates a partial stroke declaration.
+  const Stroke({this.color, this.width, this.style});
+
+  /// The stroke color.
+  final Property<Color>? color;
+
+  /// The stroke width.
+  final Property<Dimension>? width;
+
+  /// The stroke style.
+  final Property<StrokeStyle>? style;
+
+  /// Returns this stroke with non-null properties from [later] applied.
+  @override
+  Stroke merge(Stroke later) {
+    return Stroke(
+      color: later.color ?? color,
+      width: later.width ?? width,
+      style: later.style ?? style,
+    );
+  }
+}
+
+/// The visual stroke style.
+///
+/// The core model keeps this deliberately small. Platform adapters can reject
+/// unsupported values or map them to the closest target-specific stroke style.
+enum StrokeStyle {
+  /// A continuous stroke.
+  solid,
+
+  /// A dashed stroke.
+  dashed,
+
+  /// A dotted stroke.
+  dotted,
+
+  /// No visible stroke.
+  none,
+}
+
+/// A platform-neutral surface shadow.
+///
+/// A shadow is explicit paint data, not a Material elevation value. Adapter
+/// packages can map it to CSS `box-shadow`, Flutter `BoxShadow`, or ignore it
+/// when the target does not support shadows.
+final class Shadow {
+  /// Creates a shadow from zero or more [layers].
+  Shadow(Iterable<ShadowLayer> layers) : layers = List.unmodifiable(layers);
+
+  /// The shadow layers, ordered as authored.
+  final List<ShadowLayer> layers;
+
+  @override
+  bool operator ==(Object other) {
+    return other is Shadow && _listEquals(other.layers, layers);
+  }
+
+  @override
+  int get hashCode => Object.hashAll(layers);
+}
+
+/// One layer in a [Shadow].
+final class ShadowLayer {
+  /// Creates one shadow layer.
+  const ShadowLayer({
+    required this.color,
+    required this.offsetX,
+    required this.offsetY,
+    required this.blur,
+    this.spread = const Dimension.px(0),
+  });
+
+  /// The shadow color.
+  final Color color;
+
+  /// The horizontal shadow offset.
+  final Dimension offsetX;
+
+  /// The vertical shadow offset.
+  final Dimension offsetY;
+
+  /// The blur radius.
+  final Dimension blur;
+
+  /// The spread radius.
+  final Dimension spread;
+
+  @override
+  bool operator ==(Object other) {
+    return other is ShadowLayer &&
+        other.color == color &&
+        other.offsetX == offsetX &&
+        other.offsetY == offsetY &&
+        other.blur == blur &&
+        other.spread == spread;
+  }
+
+  @override
+  int get hashCode => Object.hash(color, offsetX, offsetY, blur, spread);
 }
 
 /// The visual treatment of content inside a surface.
@@ -281,4 +390,21 @@ final class Insets implements Mergeable<Insets> {
       left: later.left ?? left,
     );
   }
+}
+
+bool _listEquals<T>(List<T> a, List<T> b) {
+  if (identical(a, b)) {
+    return true;
+  }
+  if (a.length != b.length) {
+    return false;
+  }
+
+  for (var index = 0; index < a.length; index += 1) {
+    if (a[index] != b[index]) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/lib/src/style/design.dart
+++ b/lib/src/style/design.dart
@@ -370,9 +370,9 @@ Iterable<Term> _appearanceTerms(Appearance appearance) sync* {
   final surface = appearance.surface;
   if (surface != null) {
     yield* _propertyTerms(surface.fill);
-    yield* _propertyTerms(surface.stroke);
+    yield* _strokeTerms(surface.stroke);
     yield* _propertyTerms(surface.radius);
-    yield* _propertyTerms(surface.elevation);
+    yield* _propertyTerms(surface.shadow);
   }
 
   final content = appearance.content;
@@ -394,6 +394,16 @@ Iterable<Term> _appearanceTerms(Appearance appearance) sync* {
     yield* _propertyTerms(metrics.maxWidth);
     yield* _propertyTerms(metrics.maxHeight);
   }
+}
+
+Iterable<Term> _strokeTerms(Stroke? stroke) sync* {
+  if (stroke == null) {
+    return;
+  }
+
+  yield* _propertyTerms(stroke.color);
+  yield* _propertyTerms(stroke.width);
+  yield* _propertyTerms(stroke.style);
 }
 
 Iterable<Term> _insetTerms(Insets? insets) sync* {

--- a/lib/src/style/resolution.dart
+++ b/lib/src/style/resolution.dart
@@ -58,19 +58,34 @@ final class ResolvedAppearance {
 /// Resolved surface-facing visual values.
 final class ResolvedSurface {
   /// Creates a resolved surface declaration.
-  const ResolvedSurface({this.fill, this.stroke, this.radius, this.elevation});
+  const ResolvedSurface({this.fill, this.stroke, this.radius, this.shadow});
 
   /// The resolved surface fill color.
   final Color? fill;
 
-  /// The resolved stroke or border color.
-  final Color? stroke;
+  /// The resolved stroke or border treatment.
+  final ResolvedStroke? stroke;
 
   /// The resolved corner or shape radius.
   final Dimension? radius;
 
-  /// The resolved platform-neutral elevation amount or role.
-  final Dimension? elevation;
+  /// The resolved shadow cast by the surface.
+  final Shadow? shadow;
+}
+
+/// Resolved stroke values.
+final class ResolvedStroke {
+  /// Creates a resolved stroke declaration.
+  const ResolvedStroke({this.color, this.width, this.style});
+
+  /// The resolved stroke color.
+  final Color? color;
+
+  /// The resolved stroke width.
+  final Dimension? width;
+
+  /// The resolved stroke style.
+  final StrokeStyle? style;
 }
 
 /// Resolved content-facing visual values.
@@ -370,9 +385,21 @@ final class _ResolutionState {
 
     return ResolvedSurface(
       fill: resolveProperty(surface.fill),
-      stroke: resolveProperty(surface.stroke),
+      stroke: resolveStroke(surface.stroke),
       radius: resolveProperty(surface.radius),
-      elevation: resolveProperty(surface.elevation),
+      shadow: resolveProperty(surface.shadow),
+    );
+  }
+
+  ResolvedStroke? resolveStroke(Stroke? stroke) {
+    if (stroke == null) {
+      return null;
+    }
+
+    return ResolvedStroke(
+      color: resolveProperty(stroke.color),
+      width: resolveProperty(stroke.width),
+      style: resolveProperty(stroke.style),
     );
   }
 

--- a/test/example/style_primitives_test.dart
+++ b/test/example/style_primitives_test.dart
@@ -29,7 +29,12 @@ void main() {
 
     expect(resolution.diagnostics, isEmpty);
     expect(resolution.appearance.surface?.fill, const Color(0xffff7b72));
-    expect(resolution.appearance.surface?.stroke, const Color(0xff1f6feb));
+    expect(
+      resolution.appearance.surface?.stroke?.color,
+      const Color(0xff1f6feb),
+    );
+    expect(resolution.appearance.surface?.stroke?.width, 2.px);
+    expect(resolution.appearance.surface?.stroke?.style, StrokeStyle.solid);
     expect(resolution.appearance.surface?.radius, 8.px);
     expect(resolution.appearance.content?.color, const Color(0xff0d1117));
     expect(
@@ -57,10 +62,15 @@ void main() {
     expect(lightRaised.diagnostics, isEmpty);
     expect(darkOverlay.diagnostics, isEmpty);
     expect(lightRaised.appearance.surface?.fill, const Color(0xfff8f8f8));
-    expect(lightRaised.appearance.surface?.elevation, 2.px);
+    expect(lightRaised.appearance.surface?.shadow, example.raisedShadow);
     expect(darkOverlay.appearance.surface?.fill, const Color(0xff21262d));
-    expect(darkOverlay.appearance.surface?.stroke, const Color(0xff8b949e));
-    expect(darkOverlay.appearance.surface?.elevation, 8.px);
+    expect(
+      darkOverlay.appearance.surface?.stroke?.color,
+      const Color(0xff8b949e),
+    );
+    expect(darkOverlay.appearance.surface?.stroke?.width, 1.px);
+    expect(darkOverlay.appearance.surface?.stroke?.style, StrokeStyle.solid);
+    expect(darkOverlay.appearance.surface?.shadow, example.overlayShadow);
     expect(
       darkOverlay.appearance.content?.text,
       const Identifier('text.cardTitle'),
@@ -91,7 +101,12 @@ void main() {
       placeholder.appearance.content?.text,
       const Identifier('text.fieldInput'),
     );
-    expect(focusedError.appearance.surface?.stroke, const Color(0xffcf222e));
+    expect(
+      focusedError.appearance.surface?.stroke?.color,
+      const Color(0xffcf222e),
+    );
+    expect(focusedError.appearance.surface?.stroke?.width, 1.px);
+    expect(focusedError.appearance.surface?.stroke?.style, StrokeStyle.solid);
     expect(
       focusedError.appearance.content?.icon,
       const Identifier('icon.fieldError'),

--- a/test/style/appearance_test.dart
+++ b/test/style/appearance_test.dart
@@ -7,9 +7,28 @@ void main() {
     () {
       const actionFill = Term<Color>(Identifier('color.action.fill'));
       const controlRadius = Term<Dimension>(Identifier('radius.control'));
+      const strokeWidth = Term<Dimension>(Identifier('stroke.width'));
+      const strokeStyle = Term<StrokeStyle>(Identifier('stroke.style'));
+      final raisedShadow = Shadow([
+        const ShadowLayer(
+          color: Color(0x22000000),
+          offsetX: Dimension.px(0),
+          offsetY: Dimension.px(2),
+          blur: Dimension.px(8),
+        ),
+      ]);
 
       final appearance = Appearance(
-        surface: Surface(fill: .term(actionFill), radius: .term(controlRadius)),
+        surface: Surface(
+          fill: .term(actionFill),
+          stroke: Stroke(
+            color: .term(actionFill),
+            width: .term(strokeWidth),
+            style: .term(strokeStyle),
+          ),
+          radius: .term(controlRadius),
+          shadow: .literal(raisedShadow),
+        ),
         content: const Content(color: .literal(Color(0xffffffff))),
         metrics: Metrics(
           padding: Insets.symmetric(x: .literal(16.px), y: .literal(8.px)),
@@ -30,6 +49,30 @@ void main() {
           (property) => property.term,
           'term',
           same(controlRadius),
+        ),
+      );
+      expect(
+        appearance.surface?.stroke?.width,
+        isA<TermProperty<Dimension>>().having(
+          (property) => property.term,
+          'term',
+          same(strokeWidth),
+        ),
+      );
+      expect(
+        appearance.surface?.stroke?.style,
+        isA<TermProperty<StrokeStyle>>().having(
+          (property) => property.term,
+          'term',
+          same(strokeStyle),
+        ),
+      );
+      expect(
+        appearance.surface?.shadow,
+        isA<LiteralProperty<Shadow>>().having(
+          (property) => property.value,
+          'value',
+          raisedShadow,
         ),
       );
       expect(
@@ -55,19 +98,56 @@ void main() {
     const Property<Color> baseFill = .literal(Color(0xff006adc));
     const Property<Color> nextFill = .literal(Color(0xff004488));
     const Property<Dimension> radius = .literal(Dimension.px(8));
+    const Property<Dimension> strokeWidth = .literal(Dimension.px(1));
+    const Property<StrokeStyle> strokeStyle = .literal(StrokeStyle.solid);
     const Property<Color> contentColor = .literal(Color(0xffffffff));
 
     const base = Appearance(
-      surface: Surface(fill: baseFill, radius: radius),
+      surface: Surface(
+        fill: baseFill,
+        stroke: Stroke(color: baseFill, width: strokeWidth, style: strokeStyle),
+        radius: radius,
+      ),
       content: Content(color: contentColor),
     );
-    const later = Appearance(surface: Surface(fill: nextFill));
+    const later = Appearance(
+      surface: Surface(
+        fill: nextFill,
+        stroke: Stroke(color: nextFill),
+      ),
+    );
 
     final merged = base.merge(later);
 
     expect(merged.surface?.fill, same(nextFill));
+    expect(merged.surface?.stroke?.color, same(nextFill));
+    expect(merged.surface?.stroke?.width, same(strokeWidth));
+    expect(merged.surface?.stroke?.style, same(strokeStyle));
     expect(merged.surface?.radius, same(radius));
     expect(merged.content?.color, same(contentColor));
+  });
+
+  test('compares shadows by layer values', () {
+    final a = Shadow([
+      const ShadowLayer(
+        color: Color(0x33000000),
+        offsetX: Dimension.px(0),
+        offsetY: Dimension.px(4),
+        blur: Dimension.px(12),
+      ),
+    ]);
+    final b = Shadow([
+      const ShadowLayer(
+        color: Color(0x33000000),
+        offsetX: Dimension.px(0),
+        offsetY: Dimension.px(4),
+        blur: Dimension.px(12),
+      ),
+    ]);
+
+    expect(a, b);
+    expect(a.layers, isNot(same(b.layers)));
+    expect(() => a.layers.add(b.layers.single), throwsUnsupportedError);
   });
 
   test('merges metrics padding by side', () {

--- a/test/style/design_test.dart
+++ b/test/style/design_test.dart
@@ -204,6 +204,11 @@ void main() {
     const t = _AppTerms();
     const brandFill = Term<Color>(Identifier('color.brand.fill'));
     const brandRadius = Term<Dimension>(Identifier('radius.brand'));
+    const brandStrokeWidth = Term<Dimension>(Identifier('stroke.brand_width'));
+    const brandStrokeStyle = Term<StrokeStyle>(
+      Identifier('stroke.brand_style'),
+    );
+    const brandShadow = Term<Shadow>(Identifier('shadow.brand'));
 
     final diagnostics = Design(
       vocabulary: t,
@@ -211,7 +216,14 @@ void main() {
         Style<ButtonPart>(
           id: Identifier('button'),
           root: Appearance(
-            surface: Surface(fill: .term(brandFill)),
+            surface: Surface(
+              fill: .term(brandFill),
+              stroke: Stroke(
+                width: .term(brandStrokeWidth),
+                style: .term(brandStrokeStyle),
+              ),
+              shadow: .term(brandShadow),
+            ),
             content: Content(color: .term(t.color.action.content)),
           ),
           parts: {
@@ -245,6 +257,30 @@ void main() {
         code: DiagnosticCodes.styleUnknownTerm,
         targetKind: 'term',
         targetName: 'radius.brand',
+      ),
+    );
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.styleUnknownTerm,
+        targetKind: 'term',
+        targetName: 'stroke.brand_width',
+      ),
+    );
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.styleUnknownTerm,
+        targetKind: 'term',
+        targetName: 'stroke.brand_style',
+      ),
+    );
+    expect(
+      diagnostics,
+      containsDiagnostic(
+        code: DiagnosticCodes.styleUnknownTerm,
+        targetKind: 'term',
+        targetName: 'shadow.brand',
       ),
     );
     expect(

--- a/test/style/resolution_test.dart
+++ b/test/style/resolution_test.dart
@@ -31,6 +31,49 @@ void main() {
     expect(resolution.appearance.surface?.radius, 8.px);
   });
 
+  test('resolves structured stroke and shadow properties', () {
+    const strokeColor = Term<Color>(Identifier('stroke.color'));
+    const strokeWidth = Term<Dimension>(Identifier('stroke.width'));
+    const shadow = Term<Shadow>(Identifier('shadow.raised'));
+    final raisedShadow = Shadow([
+      const ShadowLayer(
+        color: Color(0x22000000),
+        offsetX: Dimension.px(0),
+        offsetY: Dimension.px(2),
+        blur: Dimension.px(8),
+      ),
+    ]);
+    final binding = Binding(Identifier('light'), [
+      strokeColor(const Color(0xffd0d7de)),
+      strokeWidth(1.px),
+      shadow(raisedShadow),
+    ]);
+    final style = Style<void>(
+      id: Identifier('card'),
+      root: const Appearance(
+        surface: Surface(
+          stroke: Stroke(
+            color: .term(strokeColor),
+            width: .term(strokeWidth),
+            style: .literal(StrokeStyle.solid),
+          ),
+          shadow: .term(shadow),
+        ),
+      ),
+    );
+
+    final resolution = style.resolve(binding: binding);
+
+    expect(resolution.diagnostics, isEmpty);
+    expect(
+      resolution.appearance.surface?.stroke?.color,
+      const Color(0xffd0d7de),
+    );
+    expect(resolution.appearance.surface?.stroke?.width, 1.px);
+    expect(resolution.appearance.surface?.stroke?.style, StrokeStyle.solid);
+    expect(resolution.appearance.surface?.shadow, raisedShadow);
+  });
+
   test('merges root part matching cases and instance override in order', () {
     const fill = Term<Color>(Identifier('color.action.fill'));
     const hoverFill = Term<Color>(Identifier('color.action.fillHover'));


### PR DESCRIPTION
## Summary

- Replace surface stroke color with a structured `Stroke` primitive.
- Replace elevation-oriented surface data with explicit `Shadow` and `ShadowLayer` primitives.
- Update resolution, design validation, examples, and tests for structured stroke and shadow terms.

## Rationale

This keeps surface primitives closer to platform-neutral style data: stroke can carry color, width, and style without losing partial overrides, while shadow uses explicit paint layers instead of a Material-like elevation value.

## Issues

No linked issue. The repository currently has no open issue for this local style primitive refinement.

## Validation

- `dart format .`
- `dart analyze .`
- `dart test`
- `dart doc --dry-run .`
- `dart run example/style_primitives.dart`